### PR TITLE
Corrected missing words/incorrect spelling

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-OpenVR is an API and runtime that allows access to VR hardware from multiple vendors without requiring that applications have specific knowledge of the hardware they are targeting. This repository is an SDK contains the API and samples. The runtime if under SteamVR in Tools on Steam. 
+OpenVR is an API and runtime that allows access to VR hardware from multiple vendors without requiring that applications have specific knowledge of the hardware they are targeting. This repository is an SDK that contains the API and samples. The runtime is under SteamVR in Tools on Steam. 
 
 Documentation for the API is available in the wiki: https://github.com/ValveSoftware/openvr/wiki/API-Documentation
 


### PR DESCRIPTION
Added missing word ("is an SDK contains" -> "is an SDK that contains") and corrected a spelling error ("The runtime if under" -> "The runtime is under")