### PR TITLE
helloworldoverlay: Specify c++11 to fix gcc errors

### DIFF
--- a/samples/helloworldoverlay/helloworldoverlay.pro
+++ b/samples/helloworldoverlay/helloworldoverlay.pro
@@ -5,6 +5,7 @@
 #-------------------------------------------------
 
 QT       += core gui
+CONFIG   += c++11
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 


### PR DESCRIPTION
Fix compile issue on gcc by specifying c++11 to avoid issue with header containing `nullptr`.
