### PR TITLE
Remove duplicate, unneeded glBindBuffer call.

### DIFF
--- a/samples/hellovr_opengl/hellovr_opengl_main.cpp
+++ b/samples/hellovr_opengl/hellovr_opengl_main.cpp
@@ -1015,8 +1015,6 @@ void CMainApplication::SetupScene()
 	glBindBuffer( GL_ARRAY_BUFFER, m_glSceneVertBuffer );
 	glBufferData( GL_ARRAY_BUFFER, sizeof(float) * vertdataarray.size(), &vertdataarray[0], GL_STATIC_DRAW);
 
-	glBindBuffer( GL_ARRAY_BUFFER, m_glSceneVertBuffer );
-
 	GLsizei stride = sizeof(VertexDataScene);
 	uintptr_t offset = 0;
 


### PR DESCRIPTION
Apart from this change, the Async pull requests should also be included to enable compilation.
https://github.com/ValveSoftware/openvr/pull/60
