### PR TITLE
replace GNUC macro with __GNUC__

### DIFF
--- a/headers/openvr.h
+++ b/headers/openvr.h
@@ -867,7 +867,7 @@ enum EVRInitError
 #define VR_INTERFACE extern "C" __declspec( dllimport )
 #endif
 
-#elif defined(GNUC) || defined(COMPILER_GCC) || defined(__APPLE__)
+#elif defined(__GNUC__) || defined(COMPILER_GCC) || defined(__APPLE__)
 
 #ifdef VR_API_EXPORT
 #define VR_INTERFACE extern "C" __attribute__((visibility("default")))

--- a/headers/openvr_capi.h
+++ b/headers/openvr_capi.h
@@ -28,7 +28,7 @@
 	#else
 	#define S_API extern "C" __declspec( dllimport ) 
 	#endif // OPENVR_API_EXPORTS
-#elif defined( GNUC )
+#elif defined(__GNUC__)
 	#if defined( OPENVR_API_EXPORTS )
 	#define S_API EXTERN_C __attribute__ ((visibility("default")))
 	#else

--- a/headers/openvr_driver.h
+++ b/headers/openvr_driver.h
@@ -867,7 +867,7 @@ enum EVRInitError
 #define VR_INTERFACE extern "C" __declspec( dllimport )
 #endif
 
-#elif defined(GNUC) || defined(COMPILER_GCC) || defined(__APPLE__)
+#elif defined(__GNUC__) || defined(COMPILER_GCC) || defined(__APPLE__)
 
 #ifdef VR_API_EXPORT
 #define VR_INTERFACE extern "C" __attribute__((visibility("default")))

--- a/samples/driver_sample/driver_sample.cpp
+++ b/samples/driver_sample/driver_sample.cpp
@@ -11,7 +11,7 @@ using namespace vr;
 #if defined(_WIN32)
 #define HMD_DLL_EXPORT extern "C" __declspec( dllexport )
 #define HMD_DLL_IMPORT extern "C" __declspec( dllimport )
-#elif defined(GNUC) || defined(COMPILER_GCC)
+#elif defined(__GNUC__) || defined(COMPILER_GCC)
 #define HMD_DLL_EXPORT extern "C" __attribute__((visibility("default")))
 #define HMD_DLL_IMPORT extern "C" 
 #else


### PR DESCRIPTION
With my GCC 5.3.0 `GNUC` is not defined by default. Instead `__GNUC__` is defined.