### PR TITLE
Fixed Process.GetCurrentProcess() build error

### DIFF
--- a/unity_package/Assets/SteamVR/Scripts/SteamVR_LoadLevel.cs
+++ b/unity_package/Assets/SteamVR/Scripts/SteamVR_LoadLevel.cs
@@ -354,7 +354,7 @@ public class SteamVR_LoadLevel : MonoBehaviour
 #if UNITY_EDITOR
 				UnityEditor.EditorApplication.isPlaying = false;
 #else
-				Process.GetCurrentProcess().Kill();
+				System.Diagnostics.Process.GetCurrentProcess().Kill();
 #endif
 			}
 		}


### PR DESCRIPTION
When building for a standalone player a compiler error popups complaining about missing class. Adding full name fixes it
