### PR TITLE
Added a method to check attached controllers.

### DIFF
--- a/unity_package/Assets/SteamVR/Scripts/SteamVR_ControllerManager.cs
+++ b/unity_package/Assets/SteamVR/Scripts/SteamVR_ControllerManager.cs
@@ -22,20 +22,7 @@ public class SteamVR_ControllerManager : MonoBehaviour
 
 	void Awake()
 	{
-		// Add left and right entries to the head of the list so we only have to operate on the list itself.
-		var additional = (this.objects != null) ? this.objects.Length : 0;
-		var objects = new GameObject[2 + additional];
-		indices = new uint[2 + additional];
-		objects[0] = right;
-		indices[0] = OpenVR.k_unTrackedDeviceIndexInvalid;
-		objects[1] = left;
-		indices[1] = OpenVR.k_unTrackedDeviceIndexInvalid;
-		for (int i = 0; i < additional; i++)
-		{
-			objects[2 + i] = this.objects[i];
-			indices[2 + i] = OpenVR.k_unTrackedDeviceIndexInvalid;
-		}
-		this.objects = objects;
+		CheckControllers();
 	}
 
 	void OnEnable()
@@ -178,6 +165,24 @@ public class SteamVR_ControllerManager : MonoBehaviour
 
 		if (changed)
 			Refresh();
+	}
+	
+	public void CheckControllers()
+	{
+		// Add left and right entries to the head of the list so we only have to operate on the list itself.
+		var additional = (this.objects != null) ? this.objects.Length : 0;
+		var objects = new GameObject[2 + additional];
+		indices = new uint[2 + additional];
+		objects[0] = right;
+		indices[0] = OpenVR.k_unTrackedDeviceIndexInvalid;
+		objects[1] = left;
+		indices[1] = OpenVR.k_unTrackedDeviceIndexInvalid;
+		for (int i = 0; i < additional; i++)
+		{
+			objects[2 + i] = this.objects[i];
+			indices[2 + i] = OpenVR.k_unTrackedDeviceIndexInvalid;
+		}
+		this.objects = objects;
 	}
 
 	public void Refresh()


### PR DESCRIPTION
If you manually create a `GameObject` then adding this script, you can't use controller because the `Awake` method is called first. This PR adds a method that we can call when the script is added and the `Awake` method already called.