### PR TITLE
Invert m_mat4HMDPose after assignment copying.

### DIFF
--- a/samples/hellovr_opengl/hellovr_opengl_main.cpp
+++ b/samples/hellovr_opengl/hellovr_opengl_main.cpp
@@ -1657,7 +1657,8 @@ void CMainApplication::UpdateHMDMatrixPose()
 
 	if ( m_rTrackedDevicePose[vr::k_unTrackedDeviceIndex_Hmd].bPoseIsValid )
 	{
-		m_mat4HMDPose = m_rmat4DevicePose[vr::k_unTrackedDeviceIndex_Hmd].invert();
+		m_mat4HMDPose = m_rmat4DevicePose[vr::k_unTrackedDeviceIndex_Hmd];
+		m_mat4HMDPose.invert();
 	}
 }
 


### PR DESCRIPTION
Invert m_mat4HMDPose after assignment to avoid mutating or double inverting the value in m_rmat4DevicePose[vr::k_unTrackedDeviceIndex_Hmd];

Matrix4.invert() works on the reference causing the original value to also be modified.
