### PR TITLE
ensure correct laser pointer rotation

### DIFF
--- a/unity_package/Assets/SteamVR/Extras/SteamVR_LaserPointer.cs
+++ b/unity_package/Assets/SteamVR/Extras/SteamVR_LaserPointer.cs
@@ -34,11 +34,13 @@ public class SteamVR_LaserPointer : MonoBehaviour
         holder = new GameObject();
         holder.transform.parent = this.transform;
         holder.transform.localPosition = Vector3.zero;
+        holder.transform.localRotation = Quaternion.identity;
 
         pointer = GameObject.CreatePrimitive(PrimitiveType.Cube);
         pointer.transform.parent = holder.transform;
         pointer.transform.localScale = new Vector3(thickness, thickness, 100f);
         pointer.transform.localPosition = new Vector3(0f, 0f, 50f);
+        pointer.transform.localRotation = Quaternion.identity;
         BoxCollider collider = pointer.GetComponent<BoxCollider>();
         if (addRigidBody)
         {


### PR DESCRIPTION
Ensure that the laser pointer's laser always points in the correct direction,
even when a parent (or any ancestor) of the SteamVR_LaserPointer has a
non-identity rotation.