### PR TITLE
include stdbool.h on non windows platform

### DIFF
--- a/headers/openvr_capi.h
+++ b/headers/openvr_capi.h
@@ -46,6 +46,8 @@
 
 #if defined( __WIN32 )
 typedef char bool;
+#else
+#include <stdbool.h>
 #endif
 
 


### PR DESCRIPTION
Tried whether https://github.com/lukexi/rumpus would compile on Linux and apparently this is missing.
