### PR TITLE
Ensure that head has a Camera component.

### DIFF
--- a/unity_package/Assets/SteamVR/Scripts/SteamVR_Camera.cs
+++ b/unity_package/Assets/SteamVR/Scripts/SteamVR_Camera.cs
@@ -283,6 +283,10 @@ public class SteamVR_Camera : MonoBehaviour
 			head.tag = tag;
 
 			var camera = head.GetComponent<Camera>();
+			if (camera == null)
+			{
+				camera = head.gameObject.AddComponent<Camera>();
+			}
 			camera.clearFlags = CameraClearFlags.Nothing;
 			camera.cullingMask = 0;
 			camera.eventMask = 0;


### PR DESCRIPTION
In SteamVR package for Unity 5.4 head GameObject does not use the SteamVR_GameView component any more. This causes that head GameObject does not to have a Camera component and fail on Expand command.

Note that head creation:
_head = new GameObject(name + headSuffix, typeof(SteamVR_GameView), typeof(SteamVR_TrackedObject)).transform;

Has become:
_head = new GameObject(name + headSuffix, typeof(SteamVR_TrackedObject)).transform;
In the Unity 5.4 plugin package.

And SteamVR_GameView has the [RequireComponent(typeof(Camera))] that created the Camera component.
