### PR TITLE
Multi-platform CMake support.

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,0 +1,213 @@
+cmake_minimum_required(VERSION 3.0.2)
+
+project(openvr_samples)
+
+# -----------------------------------------------------------------------------
+## SYSTEM PROPERTIES ##
+
+# If not set, determines the running platform architecture.
+if(NOT PLATFORM)
+  if(CMAKE_SIZEOF_VOID_P MATCHES 8)
+    set(PLATFORM 64)
+  else()
+    set(PLATFORM 32)
+  endif()
+endif()
+message(STATUS "Compilation set for ${PLATFORM}bits architectures.")
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  add_definitions(-DLINUX)
+  set(ARCH_TARGET linux64)
+
+  if(${PLATFORM} MATCHES 32)
+    message(WARNING "OpenVR x86 binaries not provided on GNU/Linux.")
+  endif()
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  add_definitions(-DOSX)
+  set(ARCH_TARGET osx32)
+
+  if(${PLATFORM} MATCHES 64)
+    message(WARNING "OpenVR x64 binaries not provided on OSX.")
+  endif()
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  add_definitions(-D_WIN32)
+  set(ARCH_TARGET win${PLATFORM})
+
+  # Binaries path for thirdparties are not generics so we try to guess their suffixes.
+  set(WINDOWS_PATH_SUFFIXES win${PLATFORM} Win${PLATFORM} x${PLATFORM})
+
+  if(${PLATFORM} MATCHES 64)
+    message(WARNING "SDL x64 runtime binaries not provided on Windows.")
+  endif()
+endif()
+
+# -----------------------------------------------------------------------------
+## PATHS ##
+
+set(THIRDPARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty)
+set(SHARED_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/shared)
+
+# Check that the steamVR SDK is installed 
+# (needed to prevent a segfault in OpenVR).
+if(CMAKE_HOST_UNIX)
+  find_file(OPENVRPATHS openvrpaths.vrpath PATHS $ENV{HOME}/.config/openvr)
+  if(${OPENVRPATHS} MATCHES OPENVRPATHS-NOTFOUND)
+    message(FATAL_ERROR "${OPENVRPATHS} Please install SteamVR SDK to continue..")
+  endif()
+endif()
+
+# Default output directory.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin/${ARCH_TARGET})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin/${ARCH_TARGET})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin/${ARCH_TARGET})
+
+# Force output directory destination, especially for MSVC (@so7747857).
+function(setTargetOutputDirectory target)
+  foreach(type RUNTIME LIBRARY ARCHIVE)
+    set_target_properties(${target} PROPERTIES
+      ${type}_OUTPUT_DIRECTORY         ${CMAKE_${type}_OUTPUT_DIRECTORY}
+      ${type}_OUTPUT_DIRECTORY_DEBUG   ${CMAKE_${type}_OUTPUT_DIRECTORY}
+      ${type}_OUTPUT_DIRECTORY_RELEASE ${CMAKE_${type}_OUTPUT_DIRECTORY}
+    )
+  endforeach()
+endfunction()
+
+# -----------------------------------------------------------------------------
+## COMPILER DETECTION ##
+
+if(   (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+   OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
+  # Better to use the prebuilt GNU preprocessor define __GNUC__,
+  # kept for legacy reason with the sample code.
+  add_definitions(-DGNUC)
+
+  set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -std=c++11 -include ${SHARED_SRC_DIR}/compat.h")
+  set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra -pedantic -g")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
+
+  # Handles x86 compilation support on x64 arch.
+  if(${PLATFORM} MATCHES 32)
+    set(CMAKE_CXX_FLAGS        "${CMAKE_CXX_FLAGS} -m32")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m32")
+  endif()
+elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
+  set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} /Za")
+  set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} /w2 /DEBUG")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MP /INCREMENTAL:NO")
+else()
+  message(FATAL_ERROR "Unsupported compiler.")
+endif()
+
+# -----------------------------------------------------------------------------
+## LIBRARIES ##
+
+## OpenGL / GLU
+find_package(OpenGL REQUIRED)
+
+## GLEW 1.11
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  # On GNU/Linux, glew can be found on the package manager. 
+  find_package(GLEW 1.11 REQUIRED)
+else()
+  # Otherwise, use the shipped binaries.
+  find_library(GLEW_LIBRARIES
+    NAMES
+      GLEW
+      glew32
+    PATHS
+      ${THIRDPARTY_DIR}/glew/glew-1.11.0/lib/Release
+    PATH_SUFFIXES
+      osx32
+      ${WINDOWS_PATH_SUFFIXES}
+  )
+  set(GLEW_INCLUDE_DIR ${THIRDPARTY_DIR}/glew/glew-1.11.0/include)
+endif()
+
+## SDL 2
+foreach(lib SDL2 SDL2main)
+  find_library(${lib}_LIBRARY
+    NAMES
+      ${lib}
+    PATHS
+      ${THIRDPARTY_DIR}/sdl2-2.0.3/bin
+    PATH_SUFFIXES
+      linux32
+      osx32
+      ${WINDOWS_PATH_SUFFIXES}
+  )
+  list(APPEND SDL2_LIBRARIES ${${lib}_LIBRARY})
+endforeach()
+set(SDL2_INCLUDE_DIR ${THIRDPARTY_DIR}/sdl2-2.0.3/include)
+
+## Qt 5
+## Important :
+## Remember to set CMAKE_PREFIX_PATH to Qt5 cmake modules path for your targeted platform
+## or set them here manually (not portable).
+# if(CMAKE_HOST_UNIX)
+#   list(APPEND CMAKE_PREFIX_PATH "/opt/Qt/5.6/gcc_64/lib/cmake")
+# else()
+#     if(${PLATFORM} MATCHES 64)
+#       set(suffix "_64")
+#     endif
+#   list(APPEND CMAKE_PREFIX_PATH "C:/Qt/5.6/msvc2013${suffix}/lib/cmake")
+# endif()
+
+# Set CMake to run moc automatically has needed.
+set(CMAKE_AUTOMOC ON)
+# Set CMake to handle *.ui generation to avoid using QT5_WRAP_UI() macro.
+set(CMAKE_AUTOUIC ON)
+# Add the build dir to include paths to find UI's headers.
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Find Qt5 libraries.
+foreach(module Core Gui Widgets)
+    find_package(Qt5 REQUIRED COMPONENTS ${module})
+    list(APPEND QT_INCLUDE_DIRS "${Qt5${module}_INCLUDE_DIRS}")
+    list(APPEND QT_LIBRARIES    "${Qt5${module}_LIBRARIES}")
+    list(APPEND QT_FLAGS        "${Qt5${module}_EXECUTABLE_COMPILE_FLAGS}")
+    list(APPEND QT_DEFINITIONS  "${Qt5${module}_DEFINITIONS}")
+endforeach()
+
+## OpenVR API path
+find_library(OPENVR_LIBRARIES
+  NAMES
+    openvr_api
+  PATHS
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bin
+    ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+  PATH_SUFFIXES
+    linux64
+    osx32
+    ${WINDOWS_PATH_SUFFIXES}
+  NO_DEFAULT_PATH
+  NO_CMAKE_FIND_ROOT_PATH
+)
+set(OPENVR_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../headers)
+
+
+# -----------------------------------------------------------------------------
+## SHARED SOURCES ##
+
+file(GLOB SHARED_SRC_FILES
+  ${SHARED_SRC_DIR}/*.cpp
+  ${SHARED_SRC_DIR}/*.h
+)
+
+include_directories(
+  .
+  ${OPENGL_INCLUDE_DIR}
+  ${GLEW_INCLUDE_DIR}
+  ${SDL2_INCLUDE_DIR}
+  ${QT_INCLUDE_DIRS}
+  ${OPENVR_INCLUDE_DIR}
+)
+
+# -----------------------------------------------------------------------------
+## SUBDIRECTORIES ##
+
+add_subdirectory(driver_sample)
+add_subdirectory(hellovr_opengl)
+add_subdirectory(helloworldoverlay)
+add_subdirectory(tracked_camera_openvr_sample)
+
+# -----------------------------------------------------------------------------

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,19 +13,17 @@
 
 * Qt 5.x
 * GLEW 1.11+
-* SDL 2
+* SDL2
 * OpenVR
 
-The only general external dependency is Qt5.
-
-On GNU/Linux, you will need GLEW 1.11 (available on most package manager).
-
+The only general external dependency is Qt5.<br/>
+On GNU/Linux, you will need GLEW 1.11 (available on most package manager).<br/>
 On Windows x64, you will need the SDL2 runtime library.
 
 ## Build
 
-**Important:**
-*you might need to specify Qt5 cmake module path manually when generating the cache for the first time using the __CMAKE_PREFIX_PATH__ macro (see examples below).*
+**Important:**<br/>
+you might need to specify Qt5 cmake module path manually when generating the cache for the first time using the __CMAKE_PREFIX_PATH__ macro (see examples below).
 
 We will use the command-line on Unix and [Git Bash](https://git-for-windows.github.io/) on Windows.
 
@@ -52,12 +50,12 @@ make -j4
 
 ### Windows
 
-Here we will use MSVC 12 for x64 platform:
+Generate the CMake cache using MSVC 12 for x64:
 ```
 cmake .. -G "Visual Studio 12 2013 Win64" -DCMAKE_PREFIX_PATH=C:/Qt/5.6/msvc2013_64/lib/cmake
 ```
 
-Alternatively, to force the compilation on x86 you can use the PLATFORM property (be sure to use the right generator and QT binaries):
+Alternatively, you can force the compilation on x86 architectures by using the **PLATFORM** property (*be sure to use the right generator and Qt binaries*):
 ```
 cmake .. -G "Visual Studio 12 2013" -DCMAKE_PREFIX_PATH=C:/Qt/5.6/msvc2013/lib/cmake -DPLATFORM=32
 ```

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,27 +2,30 @@
 
 ## Support
 
-                            32           64
-GNU/Linux   gcc 4.8+    |   OK      |    OK
-Windows     msvc 12     |   OK      |    OK
-OSX         clang       |   ~       |    ~
+|      Configuration      |    32     |    64     |
+| ----------------------- |:---------:|----------:|
+| GNU/Linux   (gcc 4.8+)  |   OK      |    OK     |
+| Windows     (msvc 12)   |   OK      |    OK     |
+| OSX         (clang)     |   ~       |    ~      |
 
 
 ## Dependencies
 
 * Qt 5.x
 * GLEW 1.11+
-* SDL 2.x
+* SDL 2
 * OpenVR
 
 The only general external dependency is Qt5.
+
 On GNU/Linux, you will need GLEW 1.11 (available on most package manager).
+
 On Windows x64, you will need the SDL2 runtime library.
 
 ## Build
 
-Important:
-you might need to specify Qt5 cmake module path manually when generating the cache for the first time using the CMAKE_PREFIX_PATH macro (see examples below).
+**Important:**
+*you might need to specify Qt5 cmake module path manually when generating the cache for the first time using the __CMAKE_PREFIX_PATH__ macro (see examples below).*
 
 We will use the command-line on Unix and [Git Bash](https://git-for-windows.github.io/) on Windows.
 
@@ -64,4 +67,6 @@ To build, simply type:
 cmake --build . --target all --config Release
 ```
 
-Note : with CMake, the build configuration type (ie. Debug, Release) is set at build time on Windows and at cache generation time on Unix.
+*Note : with CMake, the build configuration type (ie. Debug, Release) is set at build time on Windows and at cache generation time on Unix.*
+
+---

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,67 @@
+# OpenVR Samples: CMake build guide.
+
+## Support
+
+                            32           64
+GNU/Linux   gcc 4.8+    |   OK      |    OK
+Windows     msvc 12     |   OK      |    OK
+OSX         clang       |   ~       |    ~
+
+
+## Dependencies
+
+* Qt 5.x
+* GLEW 1.11+
+* SDL 2.x
+* OpenVR
+
+The only general external dependency is Qt5.
+On GNU/Linux, you will need GLEW 1.11 (available on most package manager).
+On Windows x64, you will need the SDL2 runtime library.
+
+## Build
+
+Important:
+you might need to specify Qt5 cmake module path manually when generating the cache for the first time using the CMAKE_PREFIX_PATH macro (see examples below).
+
+We will use the command-line on Unix and [Git Bash](https://git-for-windows.github.io/) on Windows.
+
+First, move from the repository root to the samples directory to create a build directory:
+```
+cd samples
+mkdir build; cd build
+```
+
+Then, depending on your system:
+
+### Unix
+
+Generate the CMake cache using Makefile:
+```
+cmake .. -G Makefile -DCMAKE_PREFIX_PATH=/opt/Qt/5.6/gcc_64/lib/cmake -DCMAKE_BUILD_TYPE=Release
+```
+
+To build type:
+```
+make -j4
+```
+
+
+### Windows
+
+Here we will use MSVC 12 for x64 platform:
+```
+cmake .. -G "Visual Studio 12 2013 Win64" -DCMAKE_PREFIX_PATH=C:/Qt/5.6/msvc2013_64/lib/cmake
+```
+
+Alternatively, to force the compilation on x86 you can use the PLATFORM property (be sure to use the right generator and QT binaries):
+```
+cmake .. -G "Visual Studio 12 2013" -DCMAKE_PREFIX_PATH=C:/Qt/5.6/msvc2013/lib/cmake -DPLATFORM=32
+```
+
+To build, simply type:
+```
+cmake --build . --target all --config Release
+```
+
+Note : with CMake, the build configuration type (ie. Debug, Release) is set at build time on Windows and at cache generation time on Unix.

--- a/samples/README.md
+++ b/samples/README.md
@@ -23,7 +23,7 @@ On Windows x64, you will need the SDL2 runtime library.
 ## Build
 
 **Important:**<br/>
-you might need to specify Qt5 cmake module path manually when generating the cache for the first time using the __CMAKE_PREFIX_PATH__ macro (see examples below).
+*you might need to specify Qt5 cmake module path manually when generating the cache for the first time using the __CMAKE_PREFIX_PATH__ macro (see examples below).*
 
 We will use the command-line on Unix and [Git Bash](https://git-for-windows.github.io/) on Windows.
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -65,6 +65,6 @@ To build, simply type:
 cmake --build . --target all --config Release
 ```
 
-*Note : with CMake, the build configuration type (ie. Debug, Release) is set at build time on Windows and at cache generation time on Unix.*
+*Note : using CMake, the build configuration type (ie. Debug, Release) is set at Build Time with MSVC and at Cache Generation Time with Makefile.*
 
 ---

--- a/samples/driver_sample/CMakeLists.txt
+++ b/samples/driver_sample/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(TARGET_NAME driver_sample)
+
+add_library(${TARGET_NAME} SHARED
+  driverlog.cpp
+  driverlog.h
+  driver_sample.cpp
+)
+
+add_definitions(-DDRIVER_SAMPLE_EXPORTS)
+
+target_link_libraries(${TARGET_NAME}
+  ${OPENVR_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+)
+
+setTargetOutputDirectory(${TARGET_NAME})

--- a/samples/driver_sample/driver_sample.cpp
+++ b/samples/driver_sample/driver_sample.cpp
@@ -137,7 +137,7 @@ EVRInitError CClientDriver_Sample::Init( vr::EClientDriverMode eDriverMode, vr::
 
 			if ( !m_bEnableNullDriver && pSettings )
 			{
-				m_bEnableNullDriver = pSettings->GetBool( k_pch_Sample_Section, k_pch_Sample_EnableSampleDriver_Bool, false );
+				m_bEnableNullDriver = pSettings->GetBool( k_pch_Sample_Section, k_pch_Sample_EnableSampleDriver_Bool);
 			}
 		}
 		m_bInit = true;
@@ -224,23 +224,23 @@ public:
 		if ( pSettings )
 		{
 			DriverLog( "Using settings values\n" );
-			m_flIPD = pSettings->GetFloat( k_pch_SteamVR_Section, k_pch_SteamVR_IPD_Float, 0.063f );
+			m_flIPD = pSettings->GetFloat( k_pch_SteamVR_Section, k_pch_SteamVR_IPD_Float );
 
 			char buf[1024];
-			pSettings->GetString( k_pch_Sample_Section, k_pch_Sample_SerialNumber_String, buf, sizeof(buf), "SAMPLE1234" );
+			pSettings->GetString( k_pch_Sample_Section, k_pch_Sample_SerialNumber_String, buf, sizeof(buf));
 			m_sSerialNumber = buf;
 
-			pSettings->GetString( k_pch_Sample_Section, k_pch_Sample_ModelNumber_String, buf, sizeof(buf), "ED209" );
+			pSettings->GetString( k_pch_Sample_Section, k_pch_Sample_ModelNumber_String, buf, sizeof(buf));
 			m_sSerialNumber = buf;
 
-			m_nWindowX = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_WindowX_Int32, 0 );
-			m_nWindowY = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_WindowY_Int32, 0 );
-			m_nWindowWidth = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_WindowWidth_Int32, 1920 );
-			m_nWindowHeight = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_WindowHeight_Int32, 1080 );
-			m_nRenderWidth = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_RenderWidth_Int32, 1344 );
-			m_nRenderHeight = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_RenderHeight_Int32, 1512 );
-			m_flSecondsFromVsyncToPhotons = pSettings->GetFloat( k_pch_Sample_Section, k_pch_Sample_SecondsFromVsyncToPhotons_Float, 0.0 );
-			m_flDisplayFrequency = pSettings->GetFloat( k_pch_Sample_Section, k_pch_Sample_DisplayFrequency_Float, 0.0 );
+			m_nWindowX = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_WindowX_Int32);
+			m_nWindowY = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_WindowY_Int32);
+			m_nWindowWidth = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_WindowWidth_Int32);
+			m_nWindowHeight = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_WindowHeight_Int32);
+			m_nRenderWidth = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_RenderWidth_Int32);
+			m_nRenderHeight = pSettings->GetInt32( k_pch_Sample_Section, k_pch_Sample_RenderHeight_Int32);
+			m_flSecondsFromVsyncToPhotons = pSettings->GetFloat( k_pch_Sample_Section, k_pch_Sample_SecondsFromVsyncToPhotons_Float);
+			m_flDisplayFrequency = pSettings->GetFloat( k_pch_Sample_Section, k_pch_Sample_DisplayFrequency_Float);
 		}
 		else
 		{
@@ -285,6 +285,10 @@ public:
 	virtual void Deactivate() 
 	{
 		m_unObjectId = vr::k_unTrackedDeviceIndexInvalid;
+	}
+
+	virtual void EnterStandby()
+	{
 	}
 
 	void *GetComponent( const char *pchComponentNameAndVersion )
@@ -585,7 +589,7 @@ EVRInitError CServerDriver_Sample::Init( IDriverLog *pDriverLog, vr::IServerDriv
 
 	IVRSettings *pSettings = pDriverHost ? pDriverHost->GetSettings( vr::IVRSettings_Version ) : NULL;
 
-	m_bEnableNullDriver = pSettings && pSettings->GetBool( k_pch_Sample_Section, k_pch_Sample_EnableSampleDriver_Bool, false );
+	m_bEnableNullDriver = pSettings && pSettings->GetBool( k_pch_Sample_Section, k_pch_Sample_EnableSampleDriver_Bool );
 
 	if ( !m_bEnableNullDriver )
 		return VRInitError_Init_HmdNotFound;

--- a/samples/hellovr_opengl/CMakeLists.txt
+++ b/samples/hellovr_opengl/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(TARGET_NAME hellovr_opengl)
+
+add_executable(${TARGET_NAME}
+  ${SHARED_SRC_FILES}
+  hellovr_opengl_main.cpp
+)
+
+target_link_libraries(${TARGET_NAME}
+  ${OPENGL_LIBRARIES}
+  ${GLEW_LIBRARIES}
+  ${SDL2_LIBRARIES}
+  ${OPENVR_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+)
+
+setTargetOutputDirectory(${TARGET_NAME})

--- a/samples/hellovr_opengl/hellovr_opengl_main.cpp
+++ b/samples/hellovr_opengl/hellovr_opengl_main.cpp
@@ -3,7 +3,7 @@
 #include <SDL.h>
 #include <GL/glew.h>
 #include <SDL_opengl.h>
-#include <gl/glu.h>
+#include <GL/glu.h>
 #include <stdio.h>
 #include <string>
 #include <cstdlib>
@@ -16,6 +16,10 @@
 
 #if defined(POSIX)
 #include "unistd.h"
+#endif
+
+#ifndef _WIN32
+#define APIENTRY
 #endif
 
 void ThreadSleep( unsigned long nMilliseconds )

--- a/samples/helloworldoverlay/CMakeLists.txt
+++ b/samples/helloworldoverlay/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(TARGET_NAME helloworldoverlay)
+
+add_executable(${TARGET_NAME}
+  ${SHARED_SRC_FILES}
+  main.cpp
+  openvroverlaycontroller.cpp
+  openvroverlaycontroller.h
+  overlaywidget.cpp
+  overlaywidget.h
+)
+
+add_definitions(${QT_DEFINITIONS})
+if(NOT "${CMAKE_BUILD_TYPE}" EQUAL "Debug")
+    add_definitions(-DQT_NO_DEBUG)
+endif()
+
+target_link_libraries(${TARGET_NAME}
+  ${QT_LIBRARIES}
+  ${OPENVR_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+)
+
+set_target_properties(${TARGET_NAME}
+  PROPERTIES
+  COMPILE_FLAGS "${QT_FLAGS}"
+)
+
+setTargetOutputDirectory(${TARGET_NAME})

--- a/samples/helloworldoverlay/openvroverlaycontroller.h
+++ b/samples/helloworldoverlay/openvroverlaycontroller.h
@@ -19,6 +19,7 @@
 #include <QtGui/QOpenGLContext>
 #include <QtWidgets/QGraphicsScene>
 #include <QOffscreenSurface>
+class QOpenGLFramebufferObject;
 
 class COpenVROverlayController : public QObject
 {

--- a/samples/shared/compat.h
+++ b/samples/shared/compat.h
@@ -1,0 +1,27 @@
+#ifndef OPENVR_SAMPLES_SHARED_COMPAT_H_
+#define OPENVR_SAMPLES_SHARED_COMPAT_H_
+
+#include <cstdio>
+#include <cstring>
+#include <cassert>
+
+// Handle non standard code.
+#ifndef _WIN32
+
+#include <cstdbool>
+#include <unistd.h>
+
+#define sprintf_s   snprintf
+#define vsprintf_s  sprintf
+#define _stricmp    strcmp
+#define stricmp     strcmp
+#define strcpy_s(dst, n, src)   int(strncpy(dst, src, n) != nullptr)
+#define fopen_s(fd, path, mode) int((*fd = fopen(path, mode)) != nullptr)
+#define _vsnprintf_s(buffer, size, fmt, ap)  vsnprintf(buffer, size, fmt, ap)
+#define OutputDebugStringA(x) fprintf(stderr, "%s\n", x)
+
+typedef int errno_t;
+
+#endif  // _WIN32
+
+#endif  // OPENVR_SAMPLES_SHARED_COMPAT_H_

--- a/samples/tracked_camera_openvr_sample/CMakeLists.txt
+++ b/samples/tracked_camera_openvr_sample/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(TARGET_NAME tracked_camera_openvr_sample)
+
+add_executable(${TARGET_NAME}
+  ${SHARED_SRC_FILES}
+  main.cpp
+  tracked_camera_openvr_sample.cpp
+  tracked_camera_openvr_sample.h
+)
+
+add_definitions(${QT_DEFINITIONS})
+if(NOT "${CMAKE_BUILD_TYPE}" EQUAL "Debug")
+    add_definitions(-DQT_NO_DEBUG)
+endif()
+
+target_link_libraries(${TARGET_NAME}
+  ${QT_LIBRARIES}
+  ${OPENVR_LIBRARIES}
+  ${CMAKE_DL_LIBS}
+)
+
+set_target_properties(${TARGET_NAME}
+  PROPERTIES
+  COMPILE_FLAGS "${QT_FLAGS}"
+)
+
+setTargetOutputDirectory(${TARGET_NAME})

--- a/samples/tracked_camera_openvr_sample/tracked_camera_openvr_sample.cpp
+++ b/samples/tracked_camera_openvr_sample/tracked_camera_openvr_sample.cpp
@@ -292,6 +292,8 @@ void CQTrackedCameraOpenVRTest::LogMessage( ELogLevel nLogLevel, const char *pMe
         m_pMessageText->insertPlainText( formattedMessage );
         m_pMessageText->moveCursor( QTextCursor::End, QTextCursor::MoveAnchor );
     }
+
+    fprintf(stderr, "%s", formattedMessage);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Hey all, 

This merge includes CMake support for **GNU/Linux** and **Windows** on both *x86* and *x64* architectures (for all non Unity samples); support for **OSX** is layered but has not been tested.

It passes compilation and runs against **GCC 4.8**, **Clang 3.5** and **MSVC 12**, but I don't own any HMD so I haven't been able to test it thoroughly (*apart for the generic "No hmd found" message*). I'll try to get my hands on one to test this but any help is very welcome :wink: .

Regardings code changes I've decided to stay minimalist, hence compatibility is mainly
achieved by the header `shared/compat.h` included at compilation time. However
few modifications were necessary concerning headers and API coherency (eg. *openvr_driver.h getters' signature vs the driver_sample code*).

For a quickstart the `sample/README.md` file explains how to build the samples.

Hopes that helps,
Cheers !