### PR TITLE
RenderModelEditor render fix

### DIFF
--- a/unity_package/Assets/SteamVR/Editor/SteamVR_RenderModelEditor.cs
+++ b/unity_package/Assets/SteamVR/Editor/SteamVR_RenderModelEditor.cs
@@ -86,7 +86,7 @@ public class SteamVR_RenderModelEditor : Editor
 
 		GUILayout.BeginHorizontal();
 		GUILayout.Label("Model Override");
-		var selected = EditorGUILayout.Popup(renderModelIndex, renderModelNames);
+		var selected = EditorGUILayout.Popup(renderModelIndex, renderModelNames ?? new string[0]);
 		if (selected != renderModelIndex)
 		{
 			renderModelIndex = selected;


### PR DESCRIPTION
I did this change on my local machine because RenderModel component (rendered by RenderModelEditor.cs) was not rendering properly.

It probably threw an exception silently during render (OnInspectorGUI).