### PR TITLE
Initial optimization for Unity FPS problem...

### DIFF
--- a/unity_package/Assets/SteamVR/Scripts/SteamVR_Render.cs
+++ b/unity_package/Assets/SteamVR/Scripts/SteamVR_Render.cs
@@ -1,4 +1,4 @@
-﻿//======= Copyright (c) Valve Corporation, All rights reserved. ===============
+//======= Copyright (c) Valve Corporation, All rights reserved. ===============
 //
 // Purpose: Handles rendering of all SteamVR_Cameras
 //
@@ -149,17 +149,25 @@ public class SteamVR_Render : MonoBehaviour
 #endif
 		}
 	}
-
+	
+	private WaitForEndOfFrame waitingForEndOfFrame = new WaitForEndOfFrame();
+	
 	private IEnumerator RenderLoop()
 	{
-		while (true)
+		
+		var overlay = SteamVR_Overlay.instance;
+        	var compositor = OpenVR.Compositor;
+		
+		while (Application.isPlaying)
 		{
-			yield return new WaitForEndOfFrame();
+			yield return waitingForEndOfFrame;
 
 			if (pauseRendering)
 				continue;
 
-			var compositor = OpenVR.Compositor;
+			if (compositor == null)
+                		compositor = OpenVR.Compositor;
+				
 			if (compositor != null)
 			{
 				if (!compositor.CanRenderScene())
@@ -181,7 +189,9 @@ public class SteamVR_Render : MonoBehaviour
 #endif
 			}
 
-			var overlay = SteamVR_Overlay.instance;
+			if (overlay == null)
+                		overlay = SteamVR_Overlay.instance;
+				
 			if (overlay != null)
 				overlay.UpdateOverlay();
 


### PR DESCRIPTION
Refering: http://steamcommunity.com/app/358720/discussions/0/341537671986065508/

Point 3. of: 

The render loop (which is generated every frame) creates a new WaitForEndOfFrame() object. Instead create a single class at the start and reference that. Check the link for all the details.

See original: https://forum.unity3d.com/threads/steamvr-htc-vive-weird-fps-issue.426904/#post-2822217