### PR TITLE
Fixes to sample code (CMake sources + compat.h)

### DIFF
--- a/samples/helloworldoverlay/CMakeLists.txt
+++ b/samples/helloworldoverlay/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(${TARGET_NAME}
 
 set_target_properties(${TARGET_NAME}
   PROPERTIES
-  COMPILE_FLAGS "${QT_FLAGS}"
+  COMPILE_FLAGS ${QT_FLAGS}
 )
 
 setTargetOutputDirectory(${TARGET_NAME})

--- a/samples/shared/compat.h
+++ b/samples/shared/compat.h
@@ -10,6 +10,7 @@
 
 #include <cstdbool>
 #include <unistd.h>
+#include <type_traits>
 
 #define sprintf_s   snprintf
 #define vsprintf_s  sprintf
@@ -21,6 +22,12 @@
 #define OutputDebugStringA(x) fprintf(stderr, "%s\n", x)
 
 typedef int errno_t;
+
+template < typename T, size_t N >
+size_t _countof( T ( & arr )[ N ] )
+{
+    return std::extent< T[ N ] >::value;
+}
 
 #endif  // _WIN32
 

--- a/samples/tracked_camera_openvr_sample/CMakeLists.txt
+++ b/samples/tracked_camera_openvr_sample/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(${TARGET_NAME}
 
 set_target_properties(${TARGET_NAME}
   PROPERTIES
-  COMPILE_FLAGS "${QT_FLAGS}"
+  COMPILE_FLAGS ${QT_FLAGS}
 )
 
 setTargetOutputDirectory(${TARGET_NAME})


### PR DESCRIPTION
* Unquoted ${QT_FLAGS} in CMakeLists.txt files to prevent "-fPIC;-fPIC;-fPIC" compiler flag.

* Added definition for _countof to compat.h.