### PR TITLE
define __stdcall to nothing on non-windows

### DIFF
--- a/headers/openvr_capi.h
+++ b/headers/openvr_capi.h
@@ -18,6 +18,9 @@
 #endif
 
 #define OPENVR_FNTABLE_CALLTYPE __stdcall
+#if !defined( _WIN32 )
+#define __stdcall
+#endif
 
 // OPENVR API export macro
 #if defined( _WIN32 ) && !defined( _X360 )


### PR DESCRIPTION
Including openvr_capi.h will fail, e.g.

```
In file included from quakedef.h:236:0,
                 from gl_refrag.c:24:
/usr/include/openvr_capi.h:1530:32: error: expected ')' before '*' token
  void (OPENVR_FNTABLE_CALLTYPE *GetRecommendedRenderTargetSize)(uint32_t * pnWidth, uint32_t * pnHeight);
                                ^
/usr/include/openvr_capi.h:1531:48: error: expected ')' before '*' token
  struct HmdMatrix44_t (OPENVR_FNTABLE_CALLTYPE *GetProjectionMatrix)(EVREye eEye, float fNearZ, float fFarZ);
                                                ^
```

and so on and so on.