### PR TITLE
Fix possible segmentation fault in VR_InitInternal

### DIFF
--- a/src/openvr_api_public.cpp
+++ b/src/openvr_api_public.cpp
@@ -38,7 +38,9 @@ uint32_t VR_InitInternal( EVRInitError *peError, vr::EVRApplicationType eApplica
 	EVRInitError err = VR_LoadHmdSystemInternal();
 	if (err != vr::VRInitError_None)
 	{
-		SharedLib_Unload(g_pVRModule);
+		if (g_pVRModule)
+			SharedLib_Unload(g_pVRModule);
+
 		g_pHmdSystem = NULL;
 		g_pVRModule = NULL;
 


### PR DESCRIPTION
It's possible that `VR_LoadHmdSystemInternal() `will return before it sets `g_pVRModule`
global pointer to a valid value. Without this change `NULL` will be passed to
`SharedLib_Unload` which on Linux will result in calling `dlclose(NULL)` which will cause a
segmentation fault.