### PR TITLE
Convert includes to MinGW friendly cases

### DIFF
--- a/samples/driver_sample/driver_sample.cpp
+++ b/samples/driver_sample/driver_sample.cpp
@@ -8,7 +8,7 @@
 #include <chrono>
 
 #if defined( _WINDOWS )
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 using namespace vr;

--- a/samples/shared/pathtools.cpp
+++ b/samples/shared/pathtools.cpp
@@ -4,11 +4,11 @@
 #include "pathtools.h"
 
 #if defined( _WIN32)
-#include <Windows.h>
+#include <windows.h>
 #include <direct.h>
-#include <Shobjidl.h>
-#include <KnownFolders.h>
-#include <Shlobj.h>
+#include <shobjidl.h>
+#include <knownfolders.h>
+#include <shlobj.h>
 
 #undef GetEnvironmentVariable
 #else

--- a/src/vrcommon/envvartools_public.cpp
+++ b/src/vrcommon/envvartools_public.cpp
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 
 #undef GetEnvironmentVariable
 #undef SetEnvironmentVariable

--- a/src/vrcommon/pathtools_public.cpp
+++ b/src/vrcommon/pathtools_public.cpp
@@ -3,11 +3,11 @@
 #include "pathtools_public.h"
 
 #if defined( _WIN32)
-#include <Windows.h>
+#include <windows.h>
 #include <direct.h>
-#include <Shobjidl.h>
-#include <KnownFolders.h>
-#include <Shlobj.h>
+#include <shobjidl.h>
+#include <knownfolders.h>
+#include <shlobj.h>
 
 #undef GetEnvironmentVariable
 #else

--- a/src/vrcommon/sharedlibtools_public.cpp
+++ b/src/vrcommon/sharedlibtools_public.cpp
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #if defined(POSIX)


### PR DESCRIPTION
MinGW has Windows.h as windows.h (and similar for other files).
Because Windows is case-insensitive, MSFT's inconsistency[0][1]
with cases doesn't matter. But for MinGW on Linux - we care.
Using the lowercase version is safe for Windows and fixes the
build for MinGW.

[0] https://github.com/Microsoft/WinObjC/issues/687
[1] http://stackoverflow.com/questions/15466613/lowercase-windows-h-and-uppercase-windows-h-difference