### PR TITLE
Add a (void*) cast to GetProcAddress

### DIFF
--- a/src/vrcommon/sharedlibtools_public.cpp
+++ b/src/vrcommon/sharedlibtools_public.cpp
@@ -22,7 +22,7 @@ SharedLibHandle SharedLib_Load( const char *pchPath )
 void *SharedLib_GetFunction( SharedLibHandle lib, const char *pchFunctionName)
 {
 #if defined( _WIN32)
-	return GetProcAddress( (HMODULE)lib, pchFunctionName );
+	return (void*)GetProcAddress( (HMODULE)lib, pchFunctionName );
 #elif defined(POSIX)
 	return dlsym( lib, pchFunctionName );
 #endif


### PR DESCRIPTION
Visual C++ has an extension that auto-magically converts a FARPROC to a void*.
On MinGW we get an error like:

In function ‘void* SharedLib_GetFunction(SharedLibHandle, const char*)’:
   openvr/src/sharedlibtools_public.cpp:25:23: error: invalid conversion from ‘FARPROC {aka int (__attribute__((__stdcall__)) *)()}’ to ‘void*’ [-fpermissive]
   return GetProcAddress( (HMODULE)lib, pchFunctionName );

See also http://stackoverflow.com/questions/13958081/mingw-compile-error-invalid-conversion-from-farproc-to-void-but-msvc-com