### PR TITLE
Support GCC Variadic Macros for MinGW

### DIFF
--- a/src/vrcommon/vrpathregistry_public.cpp
+++ b/src/vrcommon/vrpathregistry_public.cpp
@@ -23,7 +23,9 @@
 #include <algorithm>
 
 #ifndef VRLog
-	#if defined( WIN32 )
+	#if defined( __MINGW32__ )
+		#define VRLog(args...)		fprintf(stderr, args)
+	#elif defined( WIN32 )
 		#define VRLog(fmt, ...)		fprintf(stderr, fmt, __VA_ARGS__)
 	#else
 		#define VRLog(args...)		fprintf(stderr, args)


### PR DESCRIPTION
MinGW uses the GCC version of Variadic Macros, which is currently
the else case. Add a first case for MinGW.

See https://gcc.gnu.org/onlinedocs/gcc/Variadic-Macros.html