### PR TITLE
Fix a warning with gcc -Wparentheses

### DIFF
--- a/src/vrcommon/pathtools_public.cpp
+++ b/src/vrcommon/pathtools_public.cpp
@@ -655,7 +655,7 @@ bool Path_WriteBinaryFile(const std::string &strFilename, unsigned char *pData, 
 		fclose(f);
 	}
 
-	return written = nSize ? true : false;
+	return written = (nSize ? true : false);
 }
 
 std::string Path_ReadTextFile( const std::string &strFilename )


### PR DESCRIPTION
suggest parentheses around assignment used as truth value [-Wparentheses]