### PR TITLE
Install headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,4 +73,5 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 	endif()
 endif()
 
+add_subdirectory(headers)
 add_subdirectory(src)

--- a/headers/CMakeLists.txt
+++ b/headers/CMakeLists.txt
@@ -1,0 +1,1 @@
+install(FILES openvr_capi.h openvr_driver.h openvr.h DESTINATION include)


### PR DESCRIPTION
Trivial change: install header files to the include path with standard "make install".