### PR TITLE
Issue #638: Fixed C# TextureMap field types

### DIFF
--- a/headers/openvr_api.cs
+++ b/headers/openvr_api.cs
@@ -4583,15 +4583,15 @@ public enum EVRScreenshotError
 }
 [StructLayout(LayoutKind.Sequential)] public struct RenderModel_TextureMap_t
 {
-	public char unWidth;
-	public char unHeight;
+	public ushort unWidth;
+	public ushort unHeight;
 	public IntPtr rubTextureMapData; // const uint8_t *
 }
 // This structure is for backwards binary compatibility on Linux and OSX only
 [StructLayout(LayoutKind.Sequential, Pack = 4)] public struct RenderModel_TextureMap_t_Packed
 {
-	public char unWidth;
-	public char unHeight;
+	public ushort unWidth;
+	public ushort unHeight;
 	public IntPtr rubTextureMapData; // const uint8_t *
 	public RenderModel_TextureMap_t_Packed(RenderModel_TextureMap_t unpacked)
 	{


### PR DESCRIPTION
By default, Marshall.PtrToStructure converts char fields to 1 byte characters. Ushort fields are properly converted to 2 byte values.

This should fix Issue #638.