### PR TITLE
headers/openvr.h: Allow user to specify ABI type

### DIFF
--- a/headers/openvr.h
+++ b/headers/openvr.h
@@ -1523,8 +1523,21 @@ struct ImuSample_t
 
 #pragma pack( pop )
 
+#define VR_ABI_WIN32 1
+#define VR_ABI_UNIX 2
+
+#ifndef VR_ABI
+# if defined(_WIN32)
+#  define VR_ABI VR_ABI_WIN32
+# elif defined(__GNUC__) || defined(COMPILER_GCC) || defined(__APPLE__)
+#  define VR_ABI VR_ABI_UNIX
+# else
+#  error "Unsupported Platform."
+# endif
+#endif
+
 // figure out how to import from the VR API dll
-#if defined(_WIN32)
+#if VR_ABI == VR_ABI_WIN32
 
 #ifdef VR_API_EXPORT
 #define VR_INTERFACE extern "C" __declspec( dllexport )
@@ -1532,7 +1545,7 @@ struct ImuSample_t
 #define VR_INTERFACE extern "C" __declspec( dllimport )
 #endif
 
-#elif defined(__GNUC__) || defined(COMPILER_GCC) || defined(__APPLE__)
+#elif VR_ABI == VR_ABI_UNIX
 
 #ifdef VR_API_EXPORT
 #define VR_INTERFACE extern "C" __attribute__((visibility("default")))
@@ -1545,7 +1558,7 @@ struct ImuSample_t
 #endif
 
 
-#if defined( _WIN32 )
+#if VR_ABI == VR_ABI_WIN32
 #define VR_CALLTYPE __cdecl
 #else
 #define VR_CALLTYPE 


### PR DESCRIPTION
The use for this is so we can load the native Linux openvr library when building DXVK as a native Linux library. Winelib builds define `_WIN32`, but we want to use the Unix ABI for openvr, so let's let users request a specific ABI and fallback on the old logic if one is not requested.

(I think this can't be merged directly, but hopefully you can apply this diff to whatever file generates openvr.h easily enough.)