### PR TITLE
Fix compiler warning 'has virtual functions but non-virtual destructor'

### DIFF
--- a/headers/openvr.h
+++ b/headers/openvr.h
@@ -1582,7 +1582,7 @@ namespace vr
 class IVRSystem
 {
 public:
-
+	virtual ~IVRSystem() {}
 
 	// ------------------------------------
 	// Display Methods
@@ -1966,6 +1966,7 @@ namespace vr
 	class IVRApplications
 	{
 	public:
+		virtual ~IVRApplications() {}
 
 		// ---------------  Application management  --------------- //
 
@@ -2117,6 +2118,8 @@ namespace vr
 	class IVRSettings
 	{
 	public:
+		virtual ~IVRSettings() {}
+
 		virtual const char *GetSettingsErrorNameFromEnum( EVRSettingsError eError ) = 0;
 
 		// Returns true if file sync occurred (force or settings dirty)
@@ -2461,6 +2464,7 @@ enum ChaperoneCalibrationState
 class IVRChaperone
 {
 public:
+	virtual ~IVRChaperone() {}
 
 	/** Get the current state of Chaperone calibration. This state can change at any time during a session due to physical base station changes. **/
 	virtual ChaperoneCalibrationState GetCalibrationState() = 0;
@@ -2521,6 +2525,7 @@ enum EChaperoneImportFlags
 class IVRChaperoneSetup
 {
 public:
+	virtual ~IVRChaperoneSetup() {}
 
 	/** Saves the current working copy to disk */
 	virtual bool CommitWorkingCopy( EChaperoneConfigFile configFile ) = 0;
@@ -2706,6 +2711,8 @@ struct Compositor_CumulativeStats
 class IVRCompositor
 {
 public:
+	virtual ~IVRCompositor() {}
+
 	/** Sets tracking space returned by WaitGetPoses */
 	virtual void SetTrackingSpace( ETrackingUniverseOrigin eOrigin ) = 0;
 
@@ -2973,6 +2980,8 @@ typedef uint32_t VRNotificationId;
 class IVRNotifications
 {
 public:
+	virtual ~IVRNotifications() {}
+
 	/** Create a notification and enqueue it to be shown to the user.
 	* An overlay handle is required to create a notification, as otherwise it would be impossible for a user to act on it.
 	* To create a two-line notification, use a line break ('\n') to split the text into two lines.
@@ -3157,6 +3166,7 @@ namespace vr
 	class IVROverlay
 	{
 	public:
+		virtual ~IVROverlay() {}
 
 		// ---------------------------------------------
 		// Overlay management methods
@@ -3599,6 +3609,7 @@ struct RenderModel_ControllerMode_State_t
 class IVRRenderModels
 {
 public:
+	virtual ~IVRRenderModels() {}
 
 	/** Loads and returns a render model for use in the application. pchRenderModelName should be a render model name
 	* from the Prop_RenderModelName_String property or an absolute path name to a render model on disk. 
@@ -3707,6 +3718,7 @@ namespace vr
 	class IVRExtendedDisplay
 	{
 	public:
+		virtual ~IVRExtendedDisplay() {}
 
 		/** Size and position that the window needs to be on the VR display. */
 		virtual void GetWindowBounds( int32_t *pnX, int32_t *pnY, uint32_t *pnWidth, uint32_t *pnHeight ) = 0;
@@ -3734,6 +3746,8 @@ namespace vr
 class IVRTrackedCamera
 {
 public:
+	virtual ~IVRTrackedCamera() {}
+
 	/** Returns a string for an error */
 	virtual const char *GetCameraErrorNameFromEnum( vr::EVRTrackedCameraError eCameraError ) = 0;
 
@@ -3801,6 +3815,8 @@ enum EVRScreenshotError
 class IVRScreenshots
 {
 public:
+	virtual ~IVRScreenshots() {}
+
 	/** Request a screenshot of the requested type.
 	 *  A request of the VRScreenshotType_Stereo type will always
 	 *  work. Other types will depend on the underlying application
@@ -3896,6 +3912,7 @@ namespace vr
 class IVRResources
 {
 public:
+	virtual ~IVRResources() {}
 
 	// ------------------------------------
 	// Shared Resource Methods
@@ -3922,6 +3939,8 @@ namespace vr
 class IVRDriverManager
 {
 public:
+	virtual ~IVRDriverManager() {}
+
 	virtual uint32_t GetDriverCount() const = 0;
 
 	/** Returns the length of the number of bytes necessary to hold this string including the trailing null. */
@@ -4051,6 +4070,7 @@ namespace vr
 	class IVRInput
 	{
 	public:
+		virtual ~IVRInput() {}
 
 		// ---------------  Handle management   --------------- //
 
@@ -4160,6 +4180,8 @@ static const uint64_t k_ulInvalidIOBufferHandle = 0;
 	class IVRIOBuffer
 	{
 	public:
+		virtual ~IVRIOBuffer() {}
+
 		/** opens an existing or creates a new IOBuffer of unSize bytes */
 		virtual vr::EIOBufferError Open( const char *pchPath, vr::EIOBufferMode mode, uint32_t unElementSize, uint32_t unElements, vr::IOBufferHandle_t *pulBuffer ) = 0;
 		
@@ -4192,6 +4214,7 @@ namespace vr
 	class IVRSpatialAnchors
 	{
 	public:
+		virtual ~IVRSpatialAnchors() {}
 
 		/** Returns a handle for an spatial anchor described by "descriptor".  On success, pHandle
 		* will contain a handle valid for this session.  Caller can wait for an event or occasionally


### PR DESCRIPTION
Compilation currently fails when the corresponding warning is treated as an
error. This commit adds virtual destructors openvr.h with empty implementation
to avoid that warning. They are not made pure virtual so that derived classes
are not forced to implement them.