### PR TITLE
Remove semicolon that upsets clang's -Wextra-semi

### DIFF
--- a/headers/openvr.h
+++ b/headers/openvr.h
@@ -1384,7 +1384,7 @@ enum EVRSkeletalMotionRange
 
 enum EVRSkeletalTrackingLevel
 {
-	// body part location can’t be directly determined by the device. Any skeletal pose provided by 
+	// body part location can't be directly determined by the device. Any skeletal pose provided by 
 	// the device is estimated by assuming the position required to active buttons, triggers, joysticks, 
 	// or other input sensors. 
 	// E.g. Vive Controller, Gamepad
@@ -3178,7 +3178,7 @@ struct NotificationBitmap_t
 		, m_nHeight( 0 )
 		, m_nBytesPerPixel( 0 )
 	{
-	};
+	}
 
 	void *m_pImageData;
 	int32_t m_nWidth;


### PR DESCRIPTION
Also replace a smart quote encoded in ISO-8859-1 with a regular ANSI quote, to make github not complain that editing this file will transcode it to UTF-8.

No behavior change.