### PR TITLE
Fix TrackedControllerRole_Max being the same as Treadmill

### DIFF
--- a/headers/openvr.h
+++ b/headers/openvr.h
@@ -207,7 +207,7 @@ enum ETrackedControllerRole
 	TrackedControllerRole_RightHand = 2,				// Tracked device associated with the right hand
 	TrackedControllerRole_OptOut = 3,					// Tracked device is opting out of left/right hand selection
 	TrackedControllerRole_Treadmill = 4,				// Tracked device is a treadmill
-	TrackedControllerRole_Max = 4
+	TrackedControllerRole_Max = 5
 };
 
 

--- a/headers/openvr_api.json
+++ b/headers/openvr_api.json
@@ -82,7 +82,7 @@
 	,{"name": "TrackedControllerRole_RightHand","value": "2"}
 	,{"name": "TrackedControllerRole_OptOut","value": "3"}
 	,{"name": "TrackedControllerRole_Treadmill","value": "4"}
-	,{"name": "TrackedControllerRole_Max","value": "4"}
+	,{"name": "TrackedControllerRole_Max","value": "5"}
 ]}
 ,	{"enumname": "vr::ETrackingUniverseOrigin","values": [ 
 	{"name": "TrackingUniverseSeated","value": "0"}

--- a/headers/openvr_capi.h
+++ b/headers/openvr_capi.h
@@ -361,7 +361,7 @@ typedef enum ETrackedControllerRole
 	ETrackedControllerRole_TrackedControllerRole_RightHand = 2,
 	ETrackedControllerRole_TrackedControllerRole_OptOut = 3,
 	ETrackedControllerRole_TrackedControllerRole_Treadmill = 4,
-	ETrackedControllerRole_TrackedControllerRole_Max = 4,
+	ETrackedControllerRole_TrackedControllerRole_Max = 5,
 } ETrackedControllerRole;
 
 typedef enum ETrackingUniverseOrigin

--- a/headers/openvr_driver.h
+++ b/headers/openvr_driver.h
@@ -207,7 +207,7 @@ enum ETrackedControllerRole
 	TrackedControllerRole_RightHand = 2,				// Tracked device associated with the right hand
 	TrackedControllerRole_OptOut = 3,					// Tracked device is opting out of left/right hand selection
 	TrackedControllerRole_Treadmill = 4,				// Tracked device is a treadmill
-	TrackedControllerRole_Max = 4
+	TrackedControllerRole_Max = 5
 };
 
 


### PR DESCRIPTION
This didn't cause any issue on my side, but I noticed that `TrackedControllerRole_Max` was assigned the same value as `TrackedControllerRole_Treadmill`, is this intended so as to not iterate over the Treadmill enum, or is it a mistake when the Treadmill enum was introduced?