### PR TITLE
Fix OpenGL example's companion window textures

### DIFF
--- a/samples/hellovr_opengl/hellovr_opengl_main.cpp
+++ b/samples/hellovr_opengl/hellovr_opengl_main.cpp
@@ -1442,16 +1442,16 @@ void CMainApplication::SetupCompanionWindow()
 	std::vector<VertexDataWindow> vVerts;
 
 	// left eye verts
-	vVerts.push_back( VertexDataWindow( Vector2(-1, -1), Vector2(0, 1)) );
-	vVerts.push_back( VertexDataWindow( Vector2(0, -1), Vector2(1, 1)) );
-	vVerts.push_back( VertexDataWindow( Vector2(-1, 1), Vector2(0, 0)) );
-	vVerts.push_back( VertexDataWindow( Vector2(0, 1), Vector2(1, 0)) );
+        vVerts.push_back( VertexDataWindow( Vector2(-1, -1), Vector2(0, 0)) );
+        vVerts.push_back( VertexDataWindow( Vector2(0, -1), Vector2(1, 0)) );
+        vVerts.push_back( VertexDataWindow( Vector2(-1, 1), Vector2(0, 1)) );
+        vVerts.push_back( VertexDataWindow( Vector2(0, 1), Vector2(1, 1)) );
 
 	// right eye verts
-	vVerts.push_back( VertexDataWindow( Vector2(0, -1), Vector2(0, 1)) );
-	vVerts.push_back( VertexDataWindow( Vector2(1, -1), Vector2(1, 1)) );
-	vVerts.push_back( VertexDataWindow( Vector2(0, 1), Vector2(0, 0)) );
-	vVerts.push_back( VertexDataWindow( Vector2(1, 1), Vector2(1, 0)) );
+        vVerts.push_back( VertexDataWindow( Vector2(0, -1), Vector2(0, 0)) );
+        vVerts.push_back( VertexDataWindow( Vector2(1, -1), Vector2(1, 0)) );
+        vVerts.push_back( VertexDataWindow( Vector2(0, 1), Vector2(0, 1)) );
+        vVerts.push_back( VertexDataWindow( Vector2(1, 1), Vector2(1, 1)) );
 
 	GLushort vIndices[] = { 0, 1, 3,   0, 3, 2,   4, 5, 7,   4, 7, 6};
 	m_uiCompanionWindowIndexSize = _countof(vIndices);


### PR DESCRIPTION
OpenGL example's companion window is rendering the R/L views upside down.  This adjusts the texture coordinates so they rendering the textures right side up.