### PR TITLE
Rename CMake Options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,12 @@ string(REGEX REPLACE "${VERSION_BUILD_REGEX}" "\\1" VERSION_BUILD ${VERSION_BUIL
 set(OPENVR_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUILD}")
 
 # Setup some options.
-option(BUILD_SHARED "Builds the library as shared library" OFF)
-option(BUILD_FRAMEWORK "Builds the library as an apple Framework" OFF)
-option(BUILD_UNIVERSAL "Builds the shared or framework as a universal (fat, 32- & 64-bit) binary" ON)
-option(BUILD_OSX_I386 "Builds the shared or framework as a 32-bit binary, even on a 64-bit platform" OFF)
-option(USE_LIBCXX "Uses libc++ instead of libstdc++" ON)
-option(USE_CUSTOM_LIBCXX "Uses a custom libc++" OFF)
+option(OPENVR_BUILD_SHARED "Builds the library as shared library" OFF)
+option(OPENVR_BUILD_FRAMEWORK "Builds the library as an apple Framework" OFF)
+option(OPENVR_BUILD_UNIVERSAL "Builds the shared or framework as a universal (fat, 32- & 64-bit) binary" ON)
+option(OPENVR_BUILD_OSX_I386 "Builds the shared or framework as a 32-bit binary, even on a 64-bit platform" OFF)
+option(OPENVR_USE_LIBCXX "Uses libc++ instead of libstdc++" ON)
+option(OPENVR_USE_CUSTOM_LIBCXX "Uses a custom libc++" OFF)
 
 add_definitions( -DVR_API_PUBLIC )
 
@@ -42,7 +42,7 @@ endif()
 # Get platform.
 if(WIN32)
   set(PLATFORM_NAME "win")
-  if(NOT BUILD_SHARED)
+  if(NOT OPENVR_BUILD_SHARED)
     add_definitions(-DOPENVR_BUILD_STATIC)
   endif()
 elseif(UNIX AND NOT APPLE)
@@ -57,20 +57,16 @@ elseif(APPLE)
   if(CMAKE_SYSTEM_NAME MATCHES ".*Darwin.*" OR CMAKE_SYSTEM_NAME MATCHES ".*MacOS.*")
     set(PLATFORM_NAME "osx")
     add_definitions(-DOSX -DPOSIX)
-    if(BUILD_UNIVERSAL)
+    if(OPENVR_BUILD_UNIVERSAL)
       set(CMAKE_OSX_ARCHITECTURES "i386;x86_64")
     endif()
-    if(BUILD_OSX_I386)
+    if(OPENVR_BUILD_OSX_I386)
       set(PROCESSOR_ARCH "32")
       set(CMAKE_OSX_ARCHITECTURES "i386")
     endif()
   endif()
 endif()
 
-# Set output folder for static and shared libraries
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin/${PLATFORM_NAME}${PROCESSOR_ARCH})
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin/${PLATFORM_NAME}${PROCESSOR_ARCH})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin/${PLATFORM_NAME}${PROCESSOR_ARCH})
 
 # Enable some properties.
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -78,9 +74,9 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC -fvisibility=hidden")
 
 	# Set custom libc++ usage here
-	if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND USE_LIBCXX)
-		if(USE_CUSTOM_LIBCXX)
-			if(BUILD_SHARED)
+	if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND OPENVR_USE_LIBCXX)
+		if(OPENVR_USE_CUSTOM_LIBCXX)
+			if(OPENVR_BUILD_SHARED)
 				set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
 			endif()
 			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdinc++")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,22 +10,21 @@ if(APPLE)
   if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     set_source_files_properties(vrcommon/pathtools_public.cpp vrcommon/vrpathregistry_public.cpp PROPERTIES COMPILE_FLAGS "-x objective-c++")
   endif()
-  if(BUILD_SHARED OR BUILD_FRAMEWORK)
+  if(OPENVR_BUILD_SHARED OR OPENVR_BUILD_FRAMEWORK)
     find_library(FOUNDATION_FRAMEWORK Foundation)
     mark_as_advanced(FOUNDATION_FRAMEWORK)
     set(EXTRA_LIBS ${EXTRA_LIBS} ${FOUNDATION_FRAMEWORK})
-  endif(BUILD_SHARED OR BUILD_FRAMEWORK)
+  endif(OPENVR_BUILD_SHARED OR OPENVR_BUILD_FRAMEWORK)
 elseif(WIN32)
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     add_definitions( -DWIN64 )
-    set( LIBNAME "openvr_api64" )
   endif()
 endif()
 
 # Add include folders.
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../headers ${CMAKE_CURRENT_SOURCE_DIR}/vrcommon)
 
-if(USE_CUSTOM_LIBCXX)
+if(OPENVR_USE_CUSTOM_LIBCXX)
 	link_directories(
 		${LIBCXX_LIB_DIR}
 	)
@@ -66,9 +65,9 @@ source_group("VRCommon" FILES
 )
 
 # Build the library.
-if(BUILD_SHARED)
+if(OPENVR_BUILD_SHARED)
 	add_library(${LIBNAME} SHARED ${SOURCE_FILES})
-elseif(BUILD_FRAMEWORK)
+elseif(OPENVR_BUILD_FRAMEWORK)
 	set( LIBNAME "OpenVR" )
 	add_library( ${LIBNAME} 
             SHARED ${SOURCE_FILES}
@@ -94,7 +93,7 @@ else()
 	add_library(${LIBNAME} STATIC ${SOURCE_FILES})
 endif()
 
-if(USE_CUSTOM_LIBCXX)
+if(OPENVR_USE_CUSTOM_LIBCXX)
 	set(EXTRA_LIBS ${EXTRA_LIBS} c++ c++abi)
 endif()
 


### PR DESCRIPTION
Rename CMake Options to Have More specific names for better integration into larger cmake projects.