### PR TITLE
Added 'd' suffix to the name of the debug version of the static lib

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ elseif(BUILD_FRAMEWORK)
 	)
 else()
 	add_library(${LIBNAME} STATIC ${SOURCE_FILES})
+	set_target_properties(${LIBNAME} PROPERTIES ARCHIVE_OUTPUT_NAME "${LIBNAME}$<$<CONFIG:Debug>:d>")
 endif()
 
 if(USE_CUSTOM_LIBCXX)


### PR DESCRIPTION
This is more a pull question than the request. I am building the static version of the lib (`openvr_api64.lib`). By default both the debug and the release versions have the same name (on Windows) and when they are installed one basically replaces the other in the install dir. Also internally they replace each other in the target dir (`.\bin\win64`).

Whenever I by mistake try to link release to debug (or vice versa) the linker complains about non-matching symbols and even linked-in runtimes (msvcrtd vs msvcrt). So I ended up building two distinct libs with two distinct names and picking up the right one from my app build.

I wonder if it would make sense to change the build of OpenVR lib in this way too? I guess this patch might not be sufficient, but this is basically the idea. Using of the generator expression makes it work also on native the MSBuild.