### PR TITLE
samples: Fix WatchdogWakeUp usage for non-Windows platforms.

### DIFF
--- a/samples/driver_sample/driver_sample.cpp
+++ b/samples/driver_sample/driver_sample.cpp
@@ -103,7 +103,7 @@ void WatchdogThreadFunction(  )
 #else
 		// for the other platforms, just send one every five seconds
 		std::this_thread::sleep_for( std::chrono::seconds( 5 ) );
-		vr::VRWatchdogHost()->WatchdogWakeUp();
+		vr::VRWatchdogHost()->WatchdogWakeUp( vr::TrackedDeviceClass_HMD );
 #endif
 	}
 }


### PR DESCRIPTION
This patch updates API usage in the `driver_sample.cpp`, as seen in 52065df3d6f3af96300dac98cdf7397f26abfcd7 when the case `#if defined( _WINDOWS )` is not met.