### PR TITLE
Update CMakeLists Targets for integration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ if(APPLE)
 elseif(WIN32)
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     add_definitions( -DWIN64 )
-    set( LIBNAME "openvr_api64" )
+    # set( LIBNAME "openvr_api64" )
   endif()
 endif()
 
@@ -99,10 +99,45 @@ if(USE_CUSTOM_LIBCXX)
 endif()
 
 target_link_libraries(${LIBNAME} ${EXTRA_LIBS} ${CMAKE_DL_LIBS})
-target_include_directories(${LIBNAME} PUBLIC ${OPENVR_HEADER_DIR})
-
-install(TARGETS ${LIBNAME} DESTINATION lib)
+target_include_directories(${LIBNAME} 
+	PUBLIC 
+		$<BUILD_INTERFACE:${OPENVR_HEADER_DIR}>
+		$<INSTALL_INTERFACE:include>)
 install(FILES ${PUBLIC_HEADER_FILES} DESTINATION include/openvr)
+
+##### Installation targets #####
+install(TARGETS ${LIBNAME} EXPORT OpenVRTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+##### Export files #####
+if (WIN32)
+  set(PKG_PREFIX "cmake")
+else ()
+  set(PKG_PREFIX "lib/cmake/OpenVR")
+endif ()
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${CMAKE_BINARY_DIR}/OpenVRConfigVersion.cmake"
+  VERSION ${OPENVR_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
+install(EXPORT OpenVRTargets
+  FILE OpenVRTargets.cmake
+  NAMESPACE OpenVR::
+  DESTINATION ${PKG_PREFIX}
+)
+
+install(
+  FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/OpenVRConfig.cmake
+    ${CMAKE_BINARY_DIR}/OpenVRConfigVersion.cmake
+  DESTINATION ${PKG_PREFIX}
+  COMPONENT Devel
+)
+
 
 # Generate a .pc file for linux environments
 if(PLATFORM_NAME MATCHES "linux")

--- a/src/OpenVRConfig.cmake
+++ b/src/OpenVRConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/OpenVRTargets.cmake")


### PR DESCRIPTION
I have just added some configuration in the `src/CMakeLists.txt` file to get a more user-friendly integration when using the API in other applications. The modifications are : 

- Remove the possibility to have different names for the library output (this is the workaround I have found to have a universal CMake targets file, see below)
- Set the `INCLUDE_DIR` as a variable, depending on the CMake usage (BUILD/INSTALL)
- Add `EXPORT` parameter on `install` command to generate `OpenVRTargets.cmake`
- Add a new config file `OpenVRConfig.cmake`, including itself the generated  `OpenVRTargets.cmake` file

#### Build: 
```sh
git clone https://github.com/ValveSoftware/openvr.git
cd openvr && mkdir build && cd $_
cmake -DCMAKE_PREFIX_PATH=C:/api/OpenVR ..
cmake --build . --target all
cmake --build . --target install 
```
#### Output: 
```txt
C:/api/OpenVR/cmake
C:/api/OpenVR/cmake/OpenVRConfig.cmake
C:/api/OpenVR/cmake/OpenVRConfigVersion.cmake
C:/api/OpenVR/cmake/OpenVRTargets-release.cmake
C:/api/OpenVR/cmake/OpenVRTargets.cmake
C:/api/OpenVR/include
C:/api/OpenVR/include/openvr
C:/api/OpenVR/include/openvr/openvr.h
C:/api/OpenVR/include/openvr/openvr_capi.h
C:/api/OpenVR/include/openvr/openvr_driver.h
C:/api/OpenVR/lib
C:/api/OpenVR/lib/openvr_api.lib
```
#### Integration:
```cmake
find_package(OpenVR REQUIRED)
# We only need to link the library, include_dir is already set by CMake config file
target_link_libraries(myproject 
    PRIVATE OpenVR::openvr_api     # <-- namespace::targetName !
)
```

### Notes
- With this approach, we don't need a custom `FindOpenVR.cmake` file anymore.
- Including the generated targets config file in `OpenVRConfig.cmake` instead of directly have the generated content in the file is for extensibility purposes, we can always overwrite things made by CMake.
- I am not sure if set the library name as a constant `openvr_api` can break things in the workflow. It seems to be a huge change, but it makes life easier during integration, as the API has the same name, no matter the platform. Also in your distribution, the library for WIndows 64bits is not named `openvr_api64` but `openvr_api` (see in `lib/win64`  and `bin/win64` folder).

I am of course open to any change if you have better ideas to get a successful merge.