### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/src/README
+++ b/src/README
@@ -37,3 +37,14 @@ and you will end up with the static library /src/bin/<arch>/libopenvr_api.a
 To build a shared library, pass -DBUILD_SHARED=1 to cmake.
 To build as a framework on apple platforms, pass -DBUILD_FRAMEWORK=1 to cmake.
 To see a complete list of configurable build options, use `cmake -LAH`
+
+You can download and install openvr using the vcpkg(https://github.com/Microsoft/vcpkg) dependency manager:
+
+    $ git clone https://github.com/Microsoft/vcpkg.git
+    $ cd vcpkg
+    $ ./bootstrap-vcpkg.sh
+    $ ./vcpkg integrate install
+    $ vcpkg install openvr
+
+The openvr port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request(https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+


### PR DESCRIPTION
`Openvr `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for openvr and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build openvr, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/openvr/portfile.cmake). We try to keep the library maintained as close as possible to the original library.