### PR TITLE
include <sstream> in vrpathregistry_public.cpp

### DIFF
--- a/src/vrcommon/vrpathregistry_public.cpp
+++ b/src/vrcommon/vrpathregistry_public.cpp
@@ -7,6 +7,8 @@
 #include "strtools_public.h"
 #include "dirtools_public.h"
 
+#include <sstream>
+
 #if defined( WIN32 )
 #include <windows.h>
 #include <shlobj.h>


### PR DESCRIPTION
std::istringstream requires this include.
Currently it is accidentally pulled in by including json.h.
Other jsoncpp versions don't provide that include, for example with #1178
the build breaks on debian stable.