### PR TITLE
Fixed include problems and compilation errors

### DIFF
--- a/src/openvr_api_public.cpp
+++ b/src/openvr_api_public.cpp
@@ -2,12 +2,12 @@
 #define VR_API_EXPORT 1
 #include "openvr.h"
 #include "ivrclientcore.h"
-#include <vrcore/pathtools_public.h>
-#include <vrcore/sharedlibtools_public.h>
-#include <vrcore/envvartools_public.h>
-#include "hmderrors_public.h"
-#include <vrcore/strtools_public.h>
-#include <vrcore/vrpathregistry_public.h>
+#include <vrcommon/pathtools_public.h>
+#include <vrcommon/sharedlibtools_public.h>
+#include <vrcommon/envvartools_public.h>
+#include <vrcommon/hmderrors_public.h>
+#include <vrcommon/strtools_public.h>
+#include <vrcommon/vrpathregistry_public.h>
 #include <mutex>
 
 using vr::EVRInitError;

--- a/src/vrcommon/dirtools_public.cpp
+++ b/src/vrcommon/dirtools_public.cpp
@@ -1,7 +1,7 @@
 //========= Copyright Valve Corporation ============//
-#include <vrcore/dirtools_public.h>
-#include <vrcore/strtools_public.h>
-#include <vrcore/pathtools_public.h>
+#include <vrcommon/dirtools_public.h>
+#include <vrcommon/strtools_public.h>
+#include <vrcommon/pathtools_public.h>
 
 #include <errno.h>
 #include <string.h>

--- a/src/vrcommon/envvartools_public.cpp
+++ b/src/vrcommon/envvartools_public.cpp
@@ -1,6 +1,6 @@
 //========= Copyright Valve Corporation ============//
-#include <vrcore/envvartools_public.h>
-#include <vrcore/strtools_public.h>
+#include <vrcommon/envvartools_public.h>
+#include <vrcommon/strtools_public.h>
 #include <stdlib.h>
 #include <string>
 #include <cctype>

--- a/src/vrcommon/pathtools_public.cpp
+++ b/src/vrcommon/pathtools_public.cpp
@@ -1,6 +1,6 @@
 //========= Copyright Valve Corporation ============//
-#include <vrcore/strtools_public.h>
-#include <vrcore/pathtools_public.h>
+#include <vrcommon/strtools_public.h>
+#include <vrcommon/pathtools_public.h>
 
 #if defined( _WIN32)
 #include <windows.h>

--- a/src/vrcommon/sharedlibtools_public.cpp
+++ b/src/vrcommon/sharedlibtools_public.cpp
@@ -1,5 +1,5 @@
 //========= Copyright Valve Corporation ============//
-#include <vrcore/sharedlibtools_public.h>
+#include <vrcommon/sharedlibtools_public.h>
 #include <string.h>
 
 #if defined(_WIN32)

--- a/src/vrcommon/strtools_public.cpp
+++ b/src/vrcommon/strtools_public.cpp
@@ -1,5 +1,5 @@
 //========= Copyright Valve Corporation ============//
-#include <vrcore/strtools_public.h>
+#include <vrcommon/strtools_public.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -9,7 +9,7 @@
 #include <functional>
 #include <locale>
 #include <codecvt>
-#include <vrcore/assert.h>
+//#include <assert.h>
 
 #if defined( _WIN32 )
 #include <windows.h>
@@ -111,6 +111,7 @@ std::wstring UTF8to16(const char * in)
 
 std::wstring UTF8to16( const std::string & in ) { return UTF8to16( in.c_str() ); }
 
+#if defined( _WIN32 )
 //-----------------------------------------------------------------------------
 // Purpose: Format string to std::string converter
 //-----------------------------------------------------------------------------
@@ -128,7 +129,7 @@ std::string Format( const char *pchFormat, ... )
 	// Something went fairly wrong
 	if ( unSize < 0 )
 	{
-		AssertMsg( false, "Format string parse failure" );
+		//AssertMsg( false, "Format string parse failure" );
 		return "";
 	}
 
@@ -149,13 +150,13 @@ std::string Format( const char *pchFormat, ... )
 	// Double check, just in case
 	if ( unSize < 0 )
 	{
-		AssertMsg( false, "Format string parse failure" );
+		//AssertMsg( false, "Format string parse failure" );
 		return "";
 	}
 
 	return vecChar.data();
 }
-
+#endif
 
 
 

--- a/src/vrcommon/vrpathregistry_public.cpp
+++ b/src/vrcommon/vrpathregistry_public.cpp
@@ -1,11 +1,11 @@
 //========= Copyright Valve Corporation ============//
 
-#include <vrcore/vrpathregistry_public.h>
+#include <vrcommon/vrpathregistry_public.h>
 #include <json/json.h>
-#include <vrcore/pathtools_public.h>
-#include <vrcore/envvartools_public.h>
-#include <vrcore/strtools_public.h>
-#include <vrcore/dirtools_public.h>
+#include <vrcommon/pathtools_public.h>
+#include <vrcommon/envvartools_public.h>
+#include <vrcommon/strtools_public.h>
+#include <vrcommon/dirtools_public.h>
 
 #if defined( WIN32 )
 #include <windows.h>


### PR DESCRIPTION
- Replaced bad include definitions
- Define Format function as a Windows only
- Removed AssertMsg and include assert which causes problems

I tested to compile on Windows 10 and Ubuntu 21.04 and it worked on both of them. I've noticed a bit too late that an other quite similar pull request has been asked here : [https://github.com/ValveSoftware/openvr/pull/1524]. I don't know if it's a problem or not.