### PR TITLE
Make code NativeAOT compatible

### DIFF
--- a/headers/openvr_api.cs
+++ b/headers/openvr_api.cs
@@ -2023,7 +2023,7 @@ public class CVRSystem
 	IVRSystem FnTable;
 	internal CVRSystem(IntPtr pInterface)
 	{
-		FnTable = (IVRSystem)Marshal.PtrToStructure(pInterface, typeof(IVRSystem));
+		FnTable = Marshal.PtrToStructure<IVRSystem>(pInterface);
 	}
 	public void GetRecommendedRenderTargetSize(ref uint pnWidth,ref uint pnHeight)
 	{
@@ -2196,7 +2196,7 @@ public class CVRSystem
 			VREvent_t_Packed event_packed = new VREvent_t_Packed();
 			u.pPollNextEventPacked = null;
 			u.pPollNextEvent = FnTable.PollNextEvent;
-			bool packed_result = u.pPollNextEventPacked(ref event_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VREvent_t_Packed)));
+			bool packed_result = u.pPollNextEventPacked(ref event_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf<VREvent_t_Packed>());
 
 			event_packed.Unpack(ref pEvent);
 			return packed_result;
@@ -2242,7 +2242,7 @@ public class CVRSystem
 			VRControllerState_t_Packed state_packed = new VRControllerState_t_Packed(pControllerState);
 			u.pGetControllerStatePacked = null;
 			u.pGetControllerState = FnTable.GetControllerState;
-			bool packed_result = u.pGetControllerStatePacked(unControllerDeviceIndex,ref state_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VRControllerState_t_Packed)));
+			bool packed_result = u.pGetControllerStatePacked(unControllerDeviceIndex,ref state_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf<VRControllerState_t_Packed>());
 
 			state_packed.Unpack(ref pControllerState);
 			return packed_result;
@@ -2273,7 +2273,7 @@ public class CVRSystem
 			VRControllerState_t_Packed state_packed = new VRControllerState_t_Packed(pControllerState);
 			u.pGetControllerStateWithPosePacked = null;
 			u.pGetControllerStateWithPose = FnTable.GetControllerStateWithPose;
-			bool packed_result = u.pGetControllerStateWithPosePacked(eOrigin,unControllerDeviceIndex,ref state_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VRControllerState_t_Packed)),ref pTrackedDevicePose);
+			bool packed_result = u.pGetControllerStateWithPosePacked(eOrigin,unControllerDeviceIndex,ref state_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf<VRControllerState_t_Packed>(),ref pTrackedDevicePose);
 
 			state_packed.Unpack(ref pControllerState);
 			return packed_result;
@@ -2343,7 +2343,7 @@ public class CVRExtendedDisplay
 	IVRExtendedDisplay FnTable;
 	internal CVRExtendedDisplay(IntPtr pInterface)
 	{
-		FnTable = (IVRExtendedDisplay)Marshal.PtrToStructure(pInterface, typeof(IVRExtendedDisplay));
+		FnTable = Marshal.PtrToStructure<IVRExtendedDisplay>(pInterface);
 	}
 	public void GetWindowBounds(ref int pnX,ref int pnY,ref uint pnWidth,ref uint pnHeight)
 	{
@@ -2375,7 +2375,7 @@ public class CVRTrackedCamera
 	IVRTrackedCamera FnTable;
 	internal CVRTrackedCamera(IntPtr pInterface)
 	{
-		FnTable = (IVRTrackedCamera)Marshal.PtrToStructure(pInterface, typeof(IVRTrackedCamera));
+		FnTable = Marshal.PtrToStructure<IVRTrackedCamera>(pInterface);
 	}
 	public string GetCameraErrorNameFromEnum(EVRTrackedCameraError eCameraError)
 	{
@@ -2462,7 +2462,7 @@ public class CVRApplications
 	IVRApplications FnTable;
 	internal CVRApplications(IntPtr pInterface)
 	{
-		FnTable = (IVRApplications)Marshal.PtrToStructure(pInterface, typeof(IVRApplications));
+		FnTable = Marshal.PtrToStructure<IVRApplications>(pInterface);
 	}
 	public EVRApplicationError AddApplicationManifest(string pchApplicationManifestFullPath,bool bTemporary)
 	{
@@ -2674,7 +2674,7 @@ public class CVRChaperone
 	IVRChaperone FnTable;
 	internal CVRChaperone(IntPtr pInterface)
 	{
-		FnTable = (IVRChaperone)Marshal.PtrToStructure(pInterface, typeof(IVRChaperone));
+		FnTable = Marshal.PtrToStructure<IVRChaperone>(pInterface);
 	}
 	public ChaperoneCalibrationState GetCalibrationState()
 	{
@@ -2726,7 +2726,7 @@ public class CVRChaperoneSetup
 	IVRChaperoneSetup FnTable;
 	internal CVRChaperoneSetup(IntPtr pInterface)
 	{
-		FnTable = (IVRChaperoneSetup)Marshal.PtrToStructure(pInterface, typeof(IVRChaperoneSetup));
+		FnTable = Marshal.PtrToStructure<IVRChaperoneSetup>(pInterface);
 	}
 	public bool CommitWorkingCopy(EChaperoneConfigFile configFile)
 	{
@@ -2837,7 +2837,7 @@ public class CVRCompositor
 	IVRCompositor FnTable;
 	internal CVRCompositor(IntPtr pInterface)
 	{
-		FnTable = (IVRCompositor)Marshal.PtrToStructure(pInterface, typeof(IVRCompositor));
+		FnTable = Marshal.PtrToStructure<IVRCompositor>(pInterface);
 	}
 	public void SetTrackingSpace(ETrackingUniverseOrigin eOrigin)
 	{
@@ -3086,7 +3086,7 @@ public class CVROverlay
 	IVROverlay FnTable;
 	internal CVROverlay(IntPtr pInterface)
 	{
-		FnTable = (IVROverlay)Marshal.PtrToStructure(pInterface, typeof(IVROverlay));
+		FnTable = Marshal.PtrToStructure<IVROverlay>(pInterface);
 	}
 	public EVROverlayError FindOverlay(string pchOverlayKey,ref ulong pOverlayHandle)
 	{
@@ -3362,7 +3362,7 @@ public class CVROverlay
 			VREvent_t_Packed event_packed = new VREvent_t_Packed();
 			u.pPollNextOverlayEventPacked = null;
 			u.pPollNextOverlayEvent = FnTable.PollNextOverlayEvent;
-			bool packed_result = u.pPollNextOverlayEventPacked(ulOverlayHandle,ref event_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VREvent_t_Packed)));
+			bool packed_result = u.pPollNextOverlayEventPacked(ulOverlayHandle,ref event_packed,(uint)System.Runtime.InteropServices.Marshal.SizeOf<VREvent_t_Packed>());
 
 			event_packed.Unpack(ref pEvent);
 			return packed_result;
@@ -3575,7 +3575,7 @@ public class CVROverlayView
 	IVROverlayView FnTable;
 	internal CVROverlayView(IntPtr pInterface)
 	{
-		FnTable = (IVROverlayView)Marshal.PtrToStructure(pInterface, typeof(IVROverlayView));
+		FnTable = Marshal.PtrToStructure<IVROverlayView>(pInterface);
 	}
 	public EVROverlayError AcquireOverlayView(ulong ulOverlayHandle,ref VRNativeDevice_t pNativeDevice,ref VROverlayView_t pOverlayView,uint unOverlayViewSize)
 	{
@@ -3604,7 +3604,7 @@ public class CVRHeadsetView
 	IVRHeadsetView FnTable;
 	internal CVRHeadsetView(IntPtr pInterface)
 	{
-		FnTable = (IVRHeadsetView)Marshal.PtrToStructure(pInterface, typeof(IVRHeadsetView));
+		FnTable = Marshal.PtrToStructure<IVRHeadsetView>(pInterface);
 	}
 	public void SetHeadsetViewSize(uint nWidth,uint nHeight)
 	{
@@ -3657,7 +3657,7 @@ public class CVRRenderModels
 	IVRRenderModels FnTable;
 	internal CVRRenderModels(IntPtr pInterface)
 	{
-		FnTable = (IVRRenderModels)Marshal.PtrToStructure(pInterface, typeof(IVRRenderModels));
+		FnTable = Marshal.PtrToStructure<IVRRenderModels>(pInterface);
 	}
 	public EVRRenderModelError LoadRenderModel_Async(string pchRenderModelName,ref IntPtr ppRenderModel)
 	{
@@ -3815,7 +3815,7 @@ public class CVRNotifications
 	IVRNotifications FnTable;
 	internal CVRNotifications(IntPtr pInterface)
 	{
-		FnTable = (IVRNotifications)Marshal.PtrToStructure(pInterface, typeof(IVRNotifications));
+		FnTable = Marshal.PtrToStructure<IVRNotifications>(pInterface);
 	}
 	public EVRNotificationError CreateNotification(ulong ulOverlayHandle,ulong ulUserValue,EVRNotificationType type,string pchText,EVRNotificationStyle style,ref NotificationBitmap_t pImage,ref uint pNotificationId)
 	{
@@ -3838,7 +3838,7 @@ public class CVRSettings
 	IVRSettings FnTable;
 	internal CVRSettings(IntPtr pInterface)
 	{
-		FnTable = (IVRSettings)Marshal.PtrToStructure(pInterface, typeof(IVRSettings));
+		FnTable = Marshal.PtrToStructure<IVRSettings>(pInterface);
 	}
 	public string GetSettingsErrorNameFromEnum(EVRSettingsError eError)
 	{
@@ -3936,7 +3936,7 @@ public class CVRScreenshots
 	IVRScreenshots FnTable;
 	internal CVRScreenshots(IntPtr pInterface)
 	{
-		FnTable = (IVRScreenshots)Marshal.PtrToStructure(pInterface, typeof(IVRScreenshots));
+		FnTable = Marshal.PtrToStructure<IVRScreenshots>(pInterface);
 	}
 	public EVRScreenshotError RequestScreenshot(ref uint pOutScreenshotHandle,EVRScreenshotType type,string pchPreviewFilename,string pchVRFilename)
 	{
@@ -3995,7 +3995,7 @@ public class CVRResources
 	IVRResources FnTable;
 	internal CVRResources(IntPtr pInterface)
 	{
-		FnTable = (IVRResources)Marshal.PtrToStructure(pInterface, typeof(IVRResources));
+		FnTable = Marshal.PtrToStructure<IVRResources>(pInterface);
 	}
 	public uint LoadSharedResource(string pchResourceName,string pchBuffer,uint unBufferLen)
 	{
@@ -4021,7 +4021,7 @@ public class CVRDriverManager
 	IVRDriverManager FnTable;
 	internal CVRDriverManager(IntPtr pInterface)
 	{
-		FnTable = (IVRDriverManager)Marshal.PtrToStructure(pInterface, typeof(IVRDriverManager));
+		FnTable = Marshal.PtrToStructure<IVRDriverManager>(pInterface);
 	}
 	public uint GetDriverCount()
 	{
@@ -4053,7 +4053,7 @@ public class CVRInput
 	IVRInput FnTable;
 	internal CVRInput(IntPtr pInterface)
 	{
-		FnTable = (IVRInput)Marshal.PtrToStructure(pInterface, typeof(IVRInput));
+		FnTable = Marshal.PtrToStructure<IVRInput>(pInterface);
 	}
 	public EVRInputError SetActionManifestPath(string pchActionManifestPath)
 	{
@@ -4243,7 +4243,7 @@ public class CVRIOBuffer
 	IVRIOBuffer FnTable;
 	internal CVRIOBuffer(IntPtr pInterface)
 	{
-		FnTable = (IVRIOBuffer)Marshal.PtrToStructure(pInterface, typeof(IVRIOBuffer));
+		FnTable = Marshal.PtrToStructure<IVRIOBuffer>(pInterface);
 	}
 	public EIOBufferError Open(string pchPath,EIOBufferMode mode,uint unElementSize,uint unElements,ref ulong pulBuffer)
 	{
@@ -4287,7 +4287,7 @@ public class CVRSpatialAnchors
 	IVRSpatialAnchors FnTable;
 	internal CVRSpatialAnchors(IntPtr pInterface)
 	{
-		FnTable = (IVRSpatialAnchors)Marshal.PtrToStructure(pInterface, typeof(IVRSpatialAnchors));
+		FnTable = Marshal.PtrToStructure<IVRSpatialAnchors>(pInterface);
 	}
 	public EVRSpatialAnchorError CreateSpatialAnchorFromDescriptor(string pchDescriptor,ref uint pHandleOut)
 	{
@@ -4322,7 +4322,7 @@ public class CVRDebug
 	IVRDebug FnTable;
 	internal CVRDebug(IntPtr pInterface)
 	{
-		FnTable = (IVRDebug)Marshal.PtrToStructure(pInterface, typeof(IVRDebug));
+		FnTable = Marshal.PtrToStructure<IVRDebug>(pInterface);
 	}
 	public EVRDebugError EmitVrProfilerEvent(string pchMessage)
 	{
@@ -4359,7 +4359,7 @@ public class CVRProperties
 	IVRProperties FnTable;
 	internal CVRProperties(IntPtr pInterface)
 	{
-		FnTable = (IVRProperties)Marshal.PtrToStructure(pInterface, typeof(IVRProperties));
+		FnTable = Marshal.PtrToStructure<IVRProperties>(pInterface);
 	}
 	public ETrackedPropertyError ReadPropertyBatch(ulong ulContainerHandle,ref PropertyRead_t pBatch,uint unBatchEntryCount)
 	{
@@ -4389,7 +4389,7 @@ public class CVRPaths
 	IVRPaths FnTable;
 	internal CVRPaths(IntPtr pInterface)
 	{
-		FnTable = (IVRPaths)Marshal.PtrToStructure(pInterface, typeof(IVRPaths));
+		FnTable = Marshal.PtrToStructure<IVRPaths>(pInterface);
 	}
 	public ETrackedPropertyError ReadPathBatch(ulong ulRootHandle,ref PathRead_t pBatch,uint unBatchEntryCount)
 	{
@@ -4423,7 +4423,7 @@ public class CVRBlockQueue
 	IVRBlockQueue FnTable;
 	internal CVRBlockQueue(IntPtr pInterface)
 	{
-		FnTable = (IVRBlockQueue)Marshal.PtrToStructure(pInterface, typeof(IVRBlockQueue));
+		FnTable = Marshal.PtrToStructure<IVRBlockQueue>(pInterface);
 	}
 	public EBlockQueueError Create(ref ulong pulQueueHandle,string pchPath,uint unBlockDataSize,uint unBlockHeaderSize,uint unBlockCount)
 	{

--- a/samples/unity_keyboard_sample/Assets/Plugins/openvr_api.cs
+++ b/samples/unity_keyboard_sample/Assets/Plugins/openvr_api.cs
@@ -1188,7 +1188,7 @@ public class CVRSystem
 	IVRSystem FnTable;
 	internal CVRSystem(IntPtr pInterface)
 	{
-		FnTable = (IVRSystem)Marshal.PtrToStructure(pInterface, typeof(IVRSystem));
+		FnTable = Marshal.PtrToStructure<IVRSystem>(pInterface);
 	}
 	public void GetRecommendedRenderTargetSize(ref uint pnWidth,ref uint pnHeight)
 	{
@@ -1331,7 +1331,7 @@ public class CVRSystem
 	public string GetPropErrorNameFromEnum(ETrackedPropertyError error)
 	{
 		IntPtr result = FnTable.GetPropErrorNameFromEnum(error);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public bool PollNextEvent(ref VREvent_t pEvent,uint uncbVREvent)
 	{
@@ -1346,7 +1346,7 @@ public class CVRSystem
 	public string GetEventTypeNameFromEnum(EVREventType eType)
 	{
 		IntPtr result = FnTable.GetEventTypeNameFromEnum(eType);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public HiddenAreaMesh_t GetHiddenAreaMesh(EVREye eEye)
 	{
@@ -1370,12 +1370,12 @@ public class CVRSystem
 	public string GetButtonIdNameFromEnum(EVRButtonId eButtonId)
 	{
 		IntPtr result = FnTable.GetButtonIdNameFromEnum(eButtonId);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public string GetControllerAxisTypeNameFromEnum(EVRControllerAxisType eAxisType)
 	{
 		IntPtr result = FnTable.GetControllerAxisTypeNameFromEnum(eAxisType);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public bool CaptureInputFocus()
 	{
@@ -1417,7 +1417,7 @@ public class CVRExtendedDisplay
 	IVRExtendedDisplay FnTable;
 	internal CVRExtendedDisplay(IntPtr pInterface)
 	{
-		FnTable = (IVRExtendedDisplay)Marshal.PtrToStructure(pInterface, typeof(IVRExtendedDisplay));
+		FnTable = Marshal.PtrToStructure<IVRExtendedDisplay>(pInterface);
 	}
 	public void GetWindowBounds(ref int pnX,ref int pnY,ref uint pnWidth,ref uint pnHeight)
 	{
@@ -1449,7 +1449,7 @@ public class CVRApplications
 	IVRApplications FnTable;
 	internal CVRApplications(IntPtr pInterface)
 	{
-		FnTable = (IVRApplications)Marshal.PtrToStructure(pInterface, typeof(IVRApplications));
+		FnTable = Marshal.PtrToStructure<IVRApplications>(pInterface);
 	}
 	public EVRApplicationError AddApplicationManifest(string pchApplicationManifestFullPath,bool bTemporary)
 	{
@@ -1514,7 +1514,7 @@ public class CVRApplications
 	public string GetApplicationsErrorNameFromEnum(EVRApplicationError error)
 	{
 		IntPtr result = FnTable.GetApplicationsErrorNameFromEnum(error);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public uint GetApplicationPropertyString(string pchAppKey,EVRApplicationProperty eProperty,string pchPropertyValueBuffer,uint unPropertyValueBufferLen,ref EVRApplicationError peError)
 	{
@@ -1559,7 +1559,7 @@ public class CVRApplications
 	public string GetApplicationsTransitionStateNameFromEnum(EVRApplicationTransitionState state)
 	{
 		IntPtr result = FnTable.GetApplicationsTransitionStateNameFromEnum(state);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public bool IsQuitUserPromptRequested()
 	{
@@ -1579,7 +1579,7 @@ public class CVRChaperone
 	IVRChaperone FnTable;
 	internal CVRChaperone(IntPtr pInterface)
 	{
-		FnTable = (IVRChaperone)Marshal.PtrToStructure(pInterface, typeof(IVRChaperone));
+		FnTable = Marshal.PtrToStructure<IVRChaperone>(pInterface);
 	}
 	public ChaperoneCalibrationState GetCalibrationState()
 	{
@@ -1627,7 +1627,7 @@ public class CVRChaperoneSetup
 	IVRChaperoneSetup FnTable;
 	internal CVRChaperoneSetup(IntPtr pInterface)
 	{
-		FnTable = (IVRChaperoneSetup)Marshal.PtrToStructure(pInterface, typeof(IVRChaperoneSetup));
+		FnTable = Marshal.PtrToStructure<IVRChaperoneSetup>(pInterface);
 	}
 	public bool CommitWorkingCopy(EChaperoneConfigFile configFile)
 	{
@@ -1745,7 +1745,7 @@ public class CVRCompositor
 	IVRCompositor FnTable;
 	internal CVRCompositor(IntPtr pInterface)
 	{
-		FnTable = (IVRCompositor)Marshal.PtrToStructure(pInterface, typeof(IVRCompositor));
+		FnTable = Marshal.PtrToStructure<IVRCompositor>(pInterface);
 	}
 	public void SetTrackingSpace(ETrackingUniverseOrigin eOrigin)
 	{
@@ -1885,7 +1885,7 @@ public class CVROverlay
 	IVROverlay FnTable;
 	internal CVROverlay(IntPtr pInterface)
 	{
-		FnTable = (IVROverlay)Marshal.PtrToStructure(pInterface, typeof(IVROverlay));
+		FnTable = Marshal.PtrToStructure<IVROverlay>(pInterface);
 	}
 	public EVROverlayError FindOverlay(string pchOverlayKey,ref ulong pOverlayHandle)
 	{
@@ -1934,7 +1934,7 @@ public class CVROverlay
 	public string GetOverlayErrorNameFromEnum(EVROverlayError error)
 	{
 		IntPtr result = FnTable.GetOverlayErrorNameFromEnum(error);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public EVROverlayError SetOverlayRenderingPid(ulong ulOverlayHandle,uint unPID)
 	{
@@ -2246,7 +2246,7 @@ public class CVRRenderModels
 	IVRRenderModels FnTable;
 	internal CVRRenderModels(IntPtr pInterface)
 	{
-		FnTable = (IVRRenderModels)Marshal.PtrToStructure(pInterface, typeof(IVRRenderModels));
+		FnTable = Marshal.PtrToStructure<IVRRenderModels>(pInterface);
 	}
 	public EVRRenderModelError LoadRenderModel_Async(string pchRenderModelName,ref IntPtr ppRenderModel)
 	{
@@ -2328,7 +2328,7 @@ public class CVRNotifications
 	IVRNotifications FnTable;
 	internal CVRNotifications(IntPtr pInterface)
 	{
-		FnTable = (IVRNotifications)Marshal.PtrToStructure(pInterface, typeof(IVRNotifications));
+		FnTable = Marshal.PtrToStructure<IVRNotifications>(pInterface);
 	}
 	public EVRNotificationError CreateNotification(ulong ulOverlayHandle,ulong ulUserValue,EVRNotificationType type,string pchText,EVRNotificationStyle style,ref NotificationBitmap_t pImage,ref uint pNotificationId)
 	{
@@ -2349,12 +2349,12 @@ public class CVRSettings
 	IVRSettings FnTable;
 	internal CVRSettings(IntPtr pInterface)
 	{
-		FnTable = (IVRSettings)Marshal.PtrToStructure(pInterface, typeof(IVRSettings));
+		FnTable = Marshal.PtrToStructure<IVRSettings>(pInterface);
 	}
 	public string GetSettingsErrorNameFromEnum(EVRSettingsError eError)
 	{
 		IntPtr result = FnTable.GetSettingsErrorNameFromEnum(eError);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public bool Sync(bool bForce,ref EVRSettingsError peError)
 	{

--- a/samples/unity_keyboard_sample/Assets/SteamVR/Scripts/SteamVR_Overlay.cs
+++ b/samples/unity_keyboard_sample/Assets/SteamVR/Scripts/SteamVR_Overlay.cs
@@ -142,7 +142,7 @@ public class SteamVR_Overlay : MonoBehaviour
 		if (overlay == null)
 			return false;
 
-		var size = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(Valve.VR.VREvent_t));
+		var size = (uint)System.Runtime.InteropServices.Marshal.SizeOf<Valve.VR.VREvent_t>();
 		return overlay.PollNextOverlayEvent(handle, ref pEvent, size);
 	}
 

--- a/samples/unity_keyboard_sample/Assets/SteamVR/Scripts/SteamVR_Render.cs
+++ b/samples/unity_keyboard_sample/Assets/SteamVR/Scripts/SteamVR_Render.cs
@@ -372,7 +372,7 @@ public class SteamVR_Render : MonoBehaviour
 		if (system != null)
 		{
 			var vrEvent = new VREvent_t();
-			var size = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VREvent_t));
+			var size = (uint)System.Runtime.InteropServices.Marshal.SizeOf<VREvent_t>();
 			for (int i = 0; i < 64; i++)
 			{
 				if (!system.PollNextEvent(ref vrEvent, size))
@@ -419,7 +419,7 @@ public class SteamVR_Render : MonoBehaviour
 			if (vr != null)
 			{
 				var timing = new Compositor_FrameTiming();
-				timing.m_nSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(Compositor_FrameTiming));
+				timing.m_nSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<Compositor_FrameTiming>();
 				vr.compositor.GetFrameTiming(ref timing, 0);
 
 				Time.fixedDeltaTime = Time.timeScale / vr.hmd_DisplayFrequency;

--- a/samples/unity_keyboard_sample/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
+++ b/samples/unity_keyboard_sample/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
@@ -224,7 +224,7 @@ public class SteamVR_RenderModel : MonoBehaviour
 					else if (error == EVRRenderModelError.None)
 					{
 						// Preload textures as well.
-						var renderModel = (RenderModel_t)Marshal.PtrToStructure(pRenderModel, typeof(RenderModel_t));
+						var renderModel = Marshal.PtrToStructure<RenderModel_t>(pRenderModel);
 
 						// Check the cache first.
 						var material = materials[renderModel.diffuseTextureId] as Material;
@@ -321,17 +321,16 @@ public class SteamVR_RenderModel : MonoBehaviour
 			return null;
 		}
 
-        var renderModel = (RenderModel_t)Marshal.PtrToStructure(pRenderModel, typeof(RenderModel_t));
+        var renderModel = Marshal.PtrToStructure<RenderModel_t>(pRenderModel);
 
 		var vertices = new Vector3[renderModel.unVertexCount];
 		var normals = new Vector3[renderModel.unVertexCount];
 		var uv = new Vector2[renderModel.unVertexCount];
 
-		var type = typeof(RenderModel_Vertex_t);
 		for (int iVert = 0; iVert < renderModel.unVertexCount; iVert++)
 		{
-			var ptr = new System.IntPtr(renderModel.rVertexData.ToInt64() + iVert * Marshal.SizeOf(type));
-			var vert = (RenderModel_Vertex_t)Marshal.PtrToStructure(ptr, type);
+			var ptr = new System.IntPtr(renderModel.rVertexData.ToInt64() + iVert * Marshal.SizeOf<RenderModel_Vertex_t>());
+			var vert = Marshal.PtrToStructure<RenderModel_Vertex_t>(ptr);
 
 			vertices[iVert] = new Vector3(vert.vPosition.v0, vert.vPosition.v1, -vert.vPosition.v2);
 			normals[iVert] = new Vector3(vert.vNormal.v0, vert.vNormal.v1, -vert.vNormal.v2);
@@ -376,7 +375,7 @@ public class SteamVR_RenderModel : MonoBehaviour
 
 			if (error == EVRRenderModelError.None)
 			{
-				var diffuseTexture = (RenderModel_TextureMap_t)Marshal.PtrToStructure(pDiffuseTexture, typeof(RenderModel_TextureMap_t));
+				var diffuseTexture = Marshal.PtrToStructure<RenderModel_TextureMap_t>(pDiffuseTexture);
 				var texture = new Texture2D(diffuseTexture.unWidth, diffuseTexture.unHeight, TextureFormat.ARGB32, false);
 				if (SteamVR.instance.graphicsAPI == EGraphicsAPIConvention.API_DirectX)
 				{

--- a/samples/unity_keyboard_sample/Assets/SteamVR/Scripts/SteamVR_Stats.cs
+++ b/samples/unity_keyboard_sample/Assets/SteamVR/Scripts/SteamVR_Stats.cs
@@ -46,7 +46,7 @@ public class SteamVR_Stats : MonoBehaviour
 				if (compositor != null)
 				{
 					var timing = new Compositor_FrameTiming();
-					timing.m_nSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(Compositor_FrameTiming));
+					timing.m_nSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<Compositor_FrameTiming>();
 					compositor.GetFrameTiming(ref timing, 0);
 
 					var update = timing.m_flSystemTimeInSeconds;

--- a/samples/unity_teleport_sample/Assets/Plugins/openvr_api.cs
+++ b/samples/unity_teleport_sample/Assets/Plugins/openvr_api.cs
@@ -1188,7 +1188,7 @@ public class CVRSystem
 	IVRSystem FnTable;
 	internal CVRSystem(IntPtr pInterface)
 	{
-		FnTable = (IVRSystem)Marshal.PtrToStructure(pInterface, typeof(IVRSystem));
+		FnTable = Marshal.PtrToStructure<IVRSystem>(pInterface);
 	}
 	public void GetRecommendedRenderTargetSize(ref uint pnWidth,ref uint pnHeight)
 	{
@@ -1331,7 +1331,7 @@ public class CVRSystem
 	public string GetPropErrorNameFromEnum(ETrackedPropertyError error)
 	{
 		IntPtr result = FnTable.GetPropErrorNameFromEnum(error);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public bool PollNextEvent(ref VREvent_t pEvent,uint uncbVREvent)
 	{
@@ -1346,7 +1346,7 @@ public class CVRSystem
 	public string GetEventTypeNameFromEnum(EVREventType eType)
 	{
 		IntPtr result = FnTable.GetEventTypeNameFromEnum(eType);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public HiddenAreaMesh_t GetHiddenAreaMesh(EVREye eEye)
 	{
@@ -1370,12 +1370,12 @@ public class CVRSystem
 	public string GetButtonIdNameFromEnum(EVRButtonId eButtonId)
 	{
 		IntPtr result = FnTable.GetButtonIdNameFromEnum(eButtonId);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public string GetControllerAxisTypeNameFromEnum(EVRControllerAxisType eAxisType)
 	{
 		IntPtr result = FnTable.GetControllerAxisTypeNameFromEnum(eAxisType);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public bool CaptureInputFocus()
 	{
@@ -1417,7 +1417,7 @@ public class CVRExtendedDisplay
 	IVRExtendedDisplay FnTable;
 	internal CVRExtendedDisplay(IntPtr pInterface)
 	{
-		FnTable = (IVRExtendedDisplay)Marshal.PtrToStructure(pInterface, typeof(IVRExtendedDisplay));
+		FnTable = Marshal.PtrToStructure<IVRExtendedDisplay>(pInterface);
 	}
 	public void GetWindowBounds(ref int pnX,ref int pnY,ref uint pnWidth,ref uint pnHeight)
 	{
@@ -1449,7 +1449,7 @@ public class CVRApplications
 	IVRApplications FnTable;
 	internal CVRApplications(IntPtr pInterface)
 	{
-		FnTable = (IVRApplications)Marshal.PtrToStructure(pInterface, typeof(IVRApplications));
+		FnTable = Marshal.PtrToStructure<IVRApplications>(pInterface);
 	}
 	public EVRApplicationError AddApplicationManifest(string pchApplicationManifestFullPath,bool bTemporary)
 	{
@@ -1514,7 +1514,7 @@ public class CVRApplications
 	public string GetApplicationsErrorNameFromEnum(EVRApplicationError error)
 	{
 		IntPtr result = FnTable.GetApplicationsErrorNameFromEnum(error);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public uint GetApplicationPropertyString(string pchAppKey,EVRApplicationProperty eProperty,string pchPropertyValueBuffer,uint unPropertyValueBufferLen,ref EVRApplicationError peError)
 	{
@@ -1559,7 +1559,7 @@ public class CVRApplications
 	public string GetApplicationsTransitionStateNameFromEnum(EVRApplicationTransitionState state)
 	{
 		IntPtr result = FnTable.GetApplicationsTransitionStateNameFromEnum(state);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public bool IsQuitUserPromptRequested()
 	{
@@ -1579,7 +1579,7 @@ public class CVRChaperone
 	IVRChaperone FnTable;
 	internal CVRChaperone(IntPtr pInterface)
 	{
-		FnTable = (IVRChaperone)Marshal.PtrToStructure(pInterface, typeof(IVRChaperone));
+		FnTable = Marshal.PtrToStructure<IVRChaperone>(pInterface);
 	}
 	public ChaperoneCalibrationState GetCalibrationState()
 	{
@@ -1627,7 +1627,7 @@ public class CVRChaperoneSetup
 	IVRChaperoneSetup FnTable;
 	internal CVRChaperoneSetup(IntPtr pInterface)
 	{
-		FnTable = (IVRChaperoneSetup)Marshal.PtrToStructure(pInterface, typeof(IVRChaperoneSetup));
+		FnTable = Marshal.PtrToStructure<IVRChaperoneSetup>(pInterface);
 	}
 	public bool CommitWorkingCopy(EChaperoneConfigFile configFile)
 	{
@@ -1745,7 +1745,7 @@ public class CVRCompositor
 	IVRCompositor FnTable;
 	internal CVRCompositor(IntPtr pInterface)
 	{
-		FnTable = (IVRCompositor)Marshal.PtrToStructure(pInterface, typeof(IVRCompositor));
+		FnTable = Marshal.PtrToStructure<IVRCompositor>(pInterface);
 	}
 	public void SetTrackingSpace(ETrackingUniverseOrigin eOrigin)
 	{
@@ -1885,7 +1885,7 @@ public class CVROverlay
 	IVROverlay FnTable;
 	internal CVROverlay(IntPtr pInterface)
 	{
-		FnTable = (IVROverlay)Marshal.PtrToStructure(pInterface, typeof(IVROverlay));
+		FnTable = Marshal.PtrToStructure<IVROverlay>(pInterface);
 	}
 	public EVROverlayError FindOverlay(string pchOverlayKey,ref ulong pOverlayHandle)
 	{
@@ -1934,7 +1934,7 @@ public class CVROverlay
 	public string GetOverlayErrorNameFromEnum(EVROverlayError error)
 	{
 		IntPtr result = FnTable.GetOverlayErrorNameFromEnum(error);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public EVROverlayError SetOverlayRenderingPid(ulong ulOverlayHandle,uint unPID)
 	{
@@ -2246,7 +2246,7 @@ public class CVRRenderModels
 	IVRRenderModels FnTable;
 	internal CVRRenderModels(IntPtr pInterface)
 	{
-		FnTable = (IVRRenderModels)Marshal.PtrToStructure(pInterface, typeof(IVRRenderModels));
+		FnTable = Marshal.PtrToStructure<IVRRenderModels>(pInterface);
 	}
 	public EVRRenderModelError LoadRenderModel_Async(string pchRenderModelName,ref IntPtr ppRenderModel)
 	{
@@ -2328,7 +2328,7 @@ public class CVRNotifications
 	IVRNotifications FnTable;
 	internal CVRNotifications(IntPtr pInterface)
 	{
-		FnTable = (IVRNotifications)Marshal.PtrToStructure(pInterface, typeof(IVRNotifications));
+		FnTable = Marshal.PtrToStructure<IVRNotifications>(pInterface);
 	}
 	public EVRNotificationError CreateNotification(ulong ulOverlayHandle,ulong ulUserValue,EVRNotificationType type,string pchText,EVRNotificationStyle style,ref NotificationBitmap_t pImage,ref uint pNotificationId)
 	{
@@ -2349,12 +2349,12 @@ public class CVRSettings
 	IVRSettings FnTable;
 	internal CVRSettings(IntPtr pInterface)
 	{
-		FnTable = (IVRSettings)Marshal.PtrToStructure(pInterface, typeof(IVRSettings));
+		FnTable = Marshal.PtrToStructure<IVRSettings>(pInterface);
 	}
 	public string GetSettingsErrorNameFromEnum(EVRSettingsError eError)
 	{
 		IntPtr result = FnTable.GetSettingsErrorNameFromEnum(eError);
-		return (string) Marshal.PtrToStructure(result, typeof(string));
+		return Marshal.PtrToStringAnsi(result);
 	}
 	public bool Sync(bool bForce,ref EVRSettingsError peError)
 	{

--- a/samples/unity_teleport_sample/Assets/SteamVR/Scripts/SteamVR_Overlay.cs
+++ b/samples/unity_teleport_sample/Assets/SteamVR/Scripts/SteamVR_Overlay.cs
@@ -142,7 +142,7 @@ public class SteamVR_Overlay : MonoBehaviour
 		if (overlay == null)
 			return false;
 
-		var size = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(Valve.VR.VREvent_t));
+		var size = (uint)System.Runtime.InteropServices.Marshal.SizeOf<Valve.VR.VREvent_t>();
 		return overlay.PollNextOverlayEvent(handle, ref pEvent, size);
 	}
 

--- a/samples/unity_teleport_sample/Assets/SteamVR/Scripts/SteamVR_Render.cs
+++ b/samples/unity_teleport_sample/Assets/SteamVR/Scripts/SteamVR_Render.cs
@@ -372,7 +372,7 @@ public class SteamVR_Render : MonoBehaviour
 		if (system != null)
 		{
 			var vrEvent = new VREvent_t();
-			var size = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(VREvent_t));
+			var size = (uint)System.Runtime.InteropServices.Marshal.SizeOf<VREvent_t>();
 			for (int i = 0; i < 64; i++)
 			{
 				if (!system.PollNextEvent(ref vrEvent, size))
@@ -419,7 +419,7 @@ public class SteamVR_Render : MonoBehaviour
 			if (vr != null)
 			{
 				var timing = new Compositor_FrameTiming();
-				timing.m_nSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(Compositor_FrameTiming));
+				timing.m_nSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<Compositor_FrameTiming>();
 				vr.compositor.GetFrameTiming(ref timing, 0);
 
 				Time.fixedDeltaTime = Time.timeScale / vr.hmd_DisplayFrequency;

--- a/samples/unity_teleport_sample/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
+++ b/samples/unity_teleport_sample/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
@@ -224,7 +224,7 @@ public class SteamVR_RenderModel : MonoBehaviour
 					else if (error == EVRRenderModelError.None)
 					{
 						// Preload textures as well.
-						var renderModel = (RenderModel_t)Marshal.PtrToStructure(pRenderModel, typeof(RenderModel_t));
+						var renderModel = Marshal.PtrToStructure<RenderModel_t>(pRenderModel);
 
 						// Check the cache first.
 						var material = materials[renderModel.diffuseTextureId] as Material;
@@ -321,17 +321,16 @@ public class SteamVR_RenderModel : MonoBehaviour
 			return null;
 		}
 
-        var renderModel = (RenderModel_t)Marshal.PtrToStructure(pRenderModel, typeof(RenderModel_t));
+        var renderModel = Marshal.PtrToStructure<RenderModel_t>(pRenderModel);
 
 		var vertices = new Vector3[renderModel.unVertexCount];
 		var normals = new Vector3[renderModel.unVertexCount];
 		var uv = new Vector2[renderModel.unVertexCount];
 
-		var type = typeof(RenderModel_Vertex_t);
 		for (int iVert = 0; iVert < renderModel.unVertexCount; iVert++)
 		{
-			var ptr = new System.IntPtr(renderModel.rVertexData.ToInt64() + iVert * Marshal.SizeOf(type));
-			var vert = (RenderModel_Vertex_t)Marshal.PtrToStructure(ptr, type);
+			var ptr = new System.IntPtr(renderModel.rVertexData.ToInt64() + iVert * Marshal.SizeOf<RenderModel_Vertex_t>());
+			var vert = Marshal.PtrToStructure<RenderModel_Vertex_t>(ptr);
 
 			vertices[iVert] = new Vector3(vert.vPosition.v0, vert.vPosition.v1, -vert.vPosition.v2);
 			normals[iVert] = new Vector3(vert.vNormal.v0, vert.vNormal.v1, -vert.vNormal.v2);
@@ -376,7 +375,7 @@ public class SteamVR_RenderModel : MonoBehaviour
 
 			if (error == EVRRenderModelError.None)
 			{
-				var diffuseTexture = (RenderModel_TextureMap_t)Marshal.PtrToStructure(pDiffuseTexture, typeof(RenderModel_TextureMap_t));
+				var diffuseTexture = Marshal.PtrToStructure<RenderModel_TextureMap_t>(pDiffuseTexture);
 				var texture = new Texture2D(diffuseTexture.unWidth, diffuseTexture.unHeight, TextureFormat.ARGB32, false);
 				if (SteamVR.instance.graphicsAPI == EGraphicsAPIConvention.API_DirectX)
 				{

--- a/samples/unity_teleport_sample/Assets/SteamVR/Scripts/SteamVR_Stats.cs
+++ b/samples/unity_teleport_sample/Assets/SteamVR/Scripts/SteamVR_Stats.cs
@@ -46,7 +46,7 @@ public class SteamVR_Stats : MonoBehaviour
 				if (compositor != null)
 				{
 					var timing = new Compositor_FrameTiming();
-					timing.m_nSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(Compositor_FrameTiming));
+					timing.m_nSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<Compositor_FrameTiming>();
 					compositor.GetFrameTiming(ref timing, 0);
 
 					var update = timing.m_flSystemTimeInSeconds;


### PR DESCRIPTION
I know that C# files are autogenerated, but in case
 somebody what to use it without waiting for change in code gen tooling.
 This PR has 3 changes, all of them trivially can be updated in the codegen:
 - `Marshal.SizeOf(Type)` switched to `Marshal.SizeOf<T>()`
 - `Marshal.PtrToStructure(IntPtr, Type)` to `Marshal.PtrToStructure<T>(IntPtr)`
 - `Marshal.PtrToStructure<string>(IntPtr)` is gross error, and should be mapped to `Marshal.PtrToStringAnsi(IntPtr)`

This and #707 should make life of C# developer, amenable and close #638 and #472. 