### PR TITLE
Fix -G "Unix Makefiles" for linux cmake commnad

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -39,7 +39,7 @@ Then, depending on your system:
 
 Generate the CMake cache using Makefile:
 ```
-cmake .. -G Makefile -DCMAKE_PREFIX_PATH=/opt/Qt/5.6/gcc_64/lib/cmake -DCMAKE_BUILD_TYPE=Release
+cmake .. -G "Unix Makefiles" -DCMAKE_PREFIX_PATH=/opt/Qt/5.6/gcc_64/lib/cmake -DCMAKE_BUILD_TYPE=Release
 ```
 
 To build type:


### PR DESCRIPTION
Hey, that line has a typo. it should be ``-G "Unix Makefiles"``.

Without this line you get:
```
$ cmake .. -G Makefile  -DCMAKE_BUILD_TYPE=Release
CMake Error: Could not create named generator Makefile

Generators
* Unix Makefiles               = Generates standard UNIX makefiles.
  Green Hills MULTI            = Generates Green Hills MULTI files
                                 (experimental, work-in-progress).
...
```

Also
1. it might be a good idea to point that the output is generated at ``./samples/bin/linux64/helloworldoverlay`` I had to search for that too.
2. The ``-DCMAKE_PREFIX_PATH=`` is not required in most distr
3. Proff this compiles like this:
![Screenshot_20211214_184620](https://user-images.githubusercontent.com/325670/146041907-dfb63d38-5721-490b-9f83-b9242f21871b.png)


