### PR TITLE
Remove -G "Unix Makefiles" for linux cmake commnad

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -39,7 +39,7 @@ Then, depending on your system:
 
 Generate the CMake cache using Makefile:
 ```
-cmake .. -G Makefile -DCMAKE_PREFIX_PATH=/opt/Qt/5.6/gcc_64/lib/cmake -DCMAKE_BUILD_TYPE=Release
+cmake .. -DCMAKE_BUILD_TYPE=Release
 ```
 
 To build type:


### PR DESCRIPTION
As suggested in  #1618 , removing flags that are not required