### PR TITLE
fix crash when axes are rendered but m_bShowCubes is toggled off

### DIFF
--- a/samples/hellovr_dx12/hellovr_dx12_main.cpp
+++ b/samples/hellovr_dx12/hellovr_dx12_main.cpp
@@ -1718,6 +1718,16 @@ void CMainApplication::RenderScene( vr::Hmd_Eye nEye )
 		// draw the controller axis lines
 		m_pCommandList->SetPipelineState( m_pAxesPipelineState.Get() );
 
+		// Select the CBV (left or right eye)
+		CD3DX12_GPU_DESCRIPTOR_HANDLE cbvHandle(m_pCBVSRVHeap->GetGPUDescriptorHandleForHeapStart());
+		cbvHandle.Offset(nEye, m_nCBVSRVDescriptorSize);
+		m_pCommandList->SetGraphicsRootDescriptorTable(0, cbvHandle);
+
+		// SRV is just after the left eye 
+		CD3DX12_GPU_DESCRIPTOR_HANDLE srvHandle(m_pCBVSRVHeap->GetGPUDescriptorHandleForHeapStart());
+		srvHandle.Offset(SRV_TEXTURE_MAP, m_nCBVSRVDescriptorSize);
+		m_pCommandList->SetGraphicsRootDescriptorTable(1, srvHandle);
+		
 		m_pCommandList->IASetPrimitiveTopology( D3D_PRIMITIVE_TOPOLOGY_LINELIST );
 		m_pCommandList->IASetVertexBuffers( 0, 1, &m_controllerAxisVertexBufferView );
 		m_pCommandList->DrawInstanced( m_uiControllerVertcount, 1, 0, 0 );


### PR DESCRIPTION
m_bShowCubes can be toggled off by typing the letter c.
axes are rendered when a tracked device controller is connected.

when both m_bShowCubes is false and axes are rendered, the sample crashes.

this is because the g_MVPMatrix constant buffer is not being set for the axes rendering.

what was happening when m_bShowCubes was true, the axes rendering was inheriting the g_MVPMatrix constant buffer for the scene rendering.

this pr fixes the crash by always setting the g_MVPMatrix constant buffer for axes rendering.