### PR TITLE
build: add support for CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set the minimum required version of CMake for this project.
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...4.0)
 
 # Set project name.
 project(OpenVRSDK)


### PR DESCRIPTION
Trying to build the project with CMake 4.0 will result in a build error: "Compatibility with CMake < 3.5 has been removed from CMake."

To avoid this, add a conditional check for which CMake verison is being used and determine the `cmake_minimum_required` version based on that.

Another option would be to set `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` if that's preferable.